### PR TITLE
Implement MODCXEKB-32

### DIFF
--- a/src/main/java/org/folio/rest/impl/CodexInstancesResourceImpl.java
+++ b/src/main/java/org/folio/rest/impl/CodexInstancesResourceImpl.java
@@ -1,0 +1,55 @@
+package org.folio.rest.impl;
+
+import java.util.Map;
+
+import javax.ws.rs.core.Response;
+
+import org.folio.rest.annotations.Validate;
+import org.folio.rest.jaxrs.resource.CodexInstancesResource;
+
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Context;
+import io.vertx.core.Handler;
+import io.vertx.core.Vertx;
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
+
+/**
+ * Instance related codex APIs.
+ * 
+ * @author mreno
+ *
+ */
+public final class CodexInstancesResourceImpl implements CodexInstancesResource {
+  private final Logger log = LoggerFactory.getLogger(CodexInstancesResourceImpl.class);
+
+  public CodexInstancesResourceImpl(Vertx vertx, String tenantId) {
+    super();
+  }
+
+  /* (non-Javadoc)
+   * @see org.folio.rest.jaxrs.resource.InstancesResource#getCodexInstances(java.lang.String, int, int, java.lang.String, java.util.Map, io.vertx.core.Handler, io.vertx.core.Context)
+   */
+  @Override
+  @Validate
+  public void getCodexInstances(String query, int offset, int limit, String lang,
+      Map<String, String> okapiHeaders,
+      Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext)
+      throws Exception {
+    log.info("method call: getInstances");
+    throw new UnsupportedOperationException("Operation not supported.");
+  }
+
+  /* (non-Javadoc)
+   * @see org.folio.rest.jaxrs.resource.InstancesResource#getCodexInstancesById(java.lang.String, java.lang.String, java.util.Map, io.vertx.core.Handler, io.vertx.core.Context)
+   */
+  @Override
+  @Validate
+  public void getCodexInstancesById(String id, String lang,
+      Map<String, String> okapiHeaders,
+      Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext)
+      throws Exception {
+    log.info("method call: getInstancesById");
+    throw new UnsupportedOperationException("Operation not supported.");
+  }
+}


### PR DESCRIPTION
## Purpose
Created an empty implementation of CodexInstancesResource. The current
implementation logs the API call and throws
UnsupportedOperationException. These calls will be replaced with the
actual implementation. The implementation can be deployed to okapi.

Example output from mod-codex-ekb log:
`28 Nov 2017 21:17:17:643 INFO  CodexInstancesResourceImpl reqId=254962/codex-instances method call: getInstances`

Example curl:
```
curl -X GET \
  http://localhost:9130/codex-instances \
  -H 'accept: application/json' \
  -H 'x-okapi-tenant: diku' \
  -H 'x-okapi-token:
eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJkaWt1X2FkbWluIiwidXNlcl9pZCI6IjFhZDczN2IwLWQ4NDctMTFlNi1iZjI2LWNlYzBjOTMyY2UwMSIsInRlbmFudCI6ImRpa3UifQ.wPu2GaRgthy_rgA0KQC48k6kEANQ0yY65Kx-ySbkQkbGHMbg3u0MYB0ECVXGkUHYtdTFVAH8Thd1CLXLsPQDFg'

Operation not supported.
```
