### PR TITLE
Fix an inconsistency in error message reporting

### DIFF
--- a/src/main/java/org/folio/cql2rmapi/CQLParserForRMAPI.java
+++ b/src/main/java/org/folio/cql2rmapi/CQLParserForRMAPI.java
@@ -151,7 +151,7 @@ public class CQLParserForRMAPI {
 
 	private void parseCQLBooleanNode(CQLBooleanNode node) throws QueryValidationException {
 		if (node instanceof CQLAndNode) {
-		  final String MULTIPLE_FIELDS_ERROR = "Search on multiple fields is not supported";
+		  final String MULTIPLE_FIELDS_ERROR = error + "Search on multiple fields is not supported.";
 			final CQLNode leftNode = node.getLeftOperand();
 			final CQLNode rightNode = node.getRightOperand();
 			if((leftNode != null) && (rightNode != null) && ((leftNode instanceof CQLTermNode) && (rightNode instanceof CQLTermNode))) {


### PR DESCRIPTION
## Purpose
Fix an inconsistency in error message reporting when multiple search fields are not supported

## Approach
_How does this change fulfill the purpose?_

#### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.

## Learning
_Describe the research stage. Add links to blog posts, patterns, libraries or addons used to solve this problem._
