### PR TITLE
Put the CQL parser in asynchronous code.

### DIFF
--- a/src/main/java/org/folio/rest/impl/CodexInstancesResourceImpl.java
+++ b/src/main/java/org/folio/rest/impl/CodexInstancesResourceImpl.java
@@ -74,9 +74,9 @@ public final class CodexInstancesResourceImpl implements CodexInstancesResource 
     log.info("method call: getCodexInstancesById");
 
     RMAPIConfiguration.getConfiguration(okapiHeaders)
-      .thenComposeAsync(rmAPIConfig -> {
-        return RMAPIToCodex.getInstance(id, vertxContext, rmAPIConfig);
-      }).thenApplyAsync(instance -> {
+      .thenComposeAsync(rmAPIConfig ->
+        RMAPIToCodex.getInstance(id, vertxContext, rmAPIConfig)
+      ).thenApplyAsync(instance -> {
         asyncResultHandler.handle(Future.succeededFuture(
             instance == null ?
                 CodexInstancesResource.GetCodexInstancesByIdResponse.withPlainNotFound(id) :


### PR DESCRIPTION
## Purpose
Tidying the CodexInstancesResourceImpl class

## Approach
By putting the CQL parser in asynchronous code we can return immediately
from the resource impl methods. This is probably not a big deal in the
end. Also took out some old "info" logging used for debugging.
