### PR TITLE
Fix for MODCXEKB-41

### DIFF
--- a/scripts/add_rm_api_config.sh
+++ b/scripts/add_rm_api_config.sh
@@ -73,12 +73,8 @@ if [[ -z "$tenant" || -z "$rm_api_key" || -z "$rm_api_customer_id" ||
     exit 1
 fi
 
-echo "Tenant: $tenant"
-echo "RM API Key: $rm_api_key"
-echo "RM API Customer ID: $rm_api_customer_id"
-echo "RM API URL: $rm_api_url"
-echo "Okapi URL: $okapi_url"
-echo "Okapi Token: $okapi_token"
+module="EKB"
+config_name="api_access"
 
 curl -X POST \
   $okapi_url'/configurations/entries' \
@@ -88,12 +84,12 @@ curl -X POST \
   -H 'x-okapi-tenant: '$tenant \
   -H 'x-okapi-token: '$okapi_token \
   -d '{
-            "module": "KB_EBSCO",
-            "configName": "api_credentials",
-            "code": "kb.ebsco.credentials",
-            "description": "EBSCO RM-API Credentials",
+            "module": "'$module'",
+            "configName": "'$config_name'",
+            "code": "kb.ebsco.customerId",
+            "description": "EBSCO RM-API Customer ID",
             "enabled": true,
-            "value": "customer-id='$rm_api_customer_id'&api-key='$rm_api_key'"
+            "value": "'$rm_api_customer_id'"
 }'
 
 curl -X POST \
@@ -104,8 +100,24 @@ curl -X POST \
   -H 'x-okapi-tenant: '$tenant \
   -H 'x-okapi-token: '$okapi_token \
   -d '{
-            "module": "KB_EBSCO",
-            "configName": "api_credentials",
+            "module": "'$module'",
+            "configName": "'$config_name'",
+            "code": "kb.ebsco.apiKey",
+            "description": "EBSCO RM-API API Key",
+            "enabled": true,
+            "value": "'$rm_api_key'"
+}'
+
+curl -X POST \
+  $okapi_url'/configurations/entries' \
+  -H 'accept: application/json, text/plain' \
+  -H 'cache-control: no-cache' \
+  -H 'content-type: application/json' \
+  -H 'x-okapi-tenant: '$tenant \
+  -H 'x-okapi-token: '$okapi_token \
+  -d '{
+            "module": "'$module'",
+            "configName": "'$config_name'",
             "code": "kb.ebsco.url",
             "description": "EBSCO RM-API URL",
             "enabled": true,

--- a/src/test/resources/RMAPIConfiguration/mock_content_fail_empty.json
+++ b/src/test/resources/RMAPIConfiguration/mock_content_fail_empty.json
@@ -2,7 +2,7 @@
   "mocks": [
     {
       "description": "Unconfigured RM API Configuration",
-      "url": "/configurations/entries?query=%28module%3D%3DKB_EBSCO%20AND%20configName%3D%3Dapi_credentials%29",
+      "url": "/configurations/entries?query=%28module%3D%3DEKB%20AND%20configName%3D%3Dapi_access%29",
       "method": "get",
       "status": 200,
       "receivedData": {

--- a/src/test/resources/RMAPIConfiguration/mock_content_fail_missing_api_key.json
+++ b/src/test/resources/RMAPIConfiguration/mock_content_fail_missing_api_key.json
@@ -1,29 +1,43 @@
 {
   "mocks": [
     {
-      "description": "Missing customer ID RM API Configuration",
-      "url": "/configurations/entries?query=%28module%3D%3DKB_EBSCO%20AND%20configName%3D%3Dapi_credentials%29",
+      "description": "Missing API Key RM API Configuration",
+      "url": "/configurations/entries?query=%28module%3D%3DEKB%20AND%20configName%3D%3Dapi_access%29",
       "method": "get",
       "status": 200,
       "receivedData": {
         "configs" : [ {
           "id" : "ca841444-70c0-429a-9ff4-c6e3daeae324",
-          "module" : "KB_EBSCO",
-          "configName" : "api_credentials",
-          "code" : "kb.ebsco.credentials",
+          "module" : "EKB",
+          "configName" : "api_access",
+          "code" : "kb.ebsco.customerId",
           "description" : "EBSCO RM-API Credentials",
           "enabled" : true,
-          "value" : "customer-id=examplecorp",
+          "value" : "examplecorp",
           "metadata" : {
             "createdDate" : "2017-11-29T18:39:15.182+0000",
             "createdByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01",
             "updatedDate" : "2017-11-29T18:39:15.182+0000",
             "updatedByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01"
           }
+        }, {
+         "id" : "081cf659-4c9c-461f-90af-2ec8d0eded5c",
+          "module" : "EKB",
+          "configName" : "api_access",
+          "code" : "kb.ebsco.url",
+          "description" : "EBSCO RM-API URL",
+          "enabled" : true,
+          "value" : "https://sandbox.ebsco.io",
+          "metadata" : {
+            "createdDate" : "2017-12-12T14:06:19.499+0000",
+            "createdByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01",
+            "updatedDate" : "2017-12-12T14:06:19.499+0000",
+            "updatedByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01"
+          }
         } ],
-        "totalRecords" : 1,
+        "totalRecords" : 2,
         "resultInfo" : {
-          "totalRecords" : 1,
+          "totalRecords" : 2,
           "facets" : [ ]
         }
       },

--- a/src/test/resources/RMAPIConfiguration/mock_content_fail_missing_customer_id.json
+++ b/src/test/resources/RMAPIConfiguration/mock_content_fail_missing_customer_id.json
@@ -2,28 +2,42 @@
   "mocks": [
     {
       "description": "Missing customer ID RM API Configuration",
-      "url": "/configurations/entries?query=%28module%3D%3DKB_EBSCO%20AND%20configName%3D%3Dapi_credentials%29",
+      "url": "/configurations/entries?query=%28module%3D%3DEKB%20AND%20configName%3D%3Dapi_access%29",
       "method": "get",
       "status": 200,
       "receivedData": {
         "configs" : [ {
           "id" : "ca841444-70c0-429a-9ff4-c6e3daeae324",
-          "module" : "KB_EBSCO",
-          "configName" : "api_credentials",
-          "code" : "kb.ebsco.credentials",
+          "module" : "EKB",
+          "configName" : "api_access",
+          "code" : "kb.ebsco.apiKey",
           "description" : "EBSCO RM-API Credentials",
           "enabled" : true,
-          "value" : "api-key=8675309",
+          "value" : "8675309",
           "metadata" : {
             "createdDate" : "2017-11-29T18:39:15.182+0000",
             "createdByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01",
             "updatedDate" : "2017-11-29T18:39:15.182+0000",
             "updatedByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01"
           }
+        }, {
+          "id" : "081cf659-4c9c-461f-90af-2ec8d0eded5c",
+          "module" : "EKB",
+          "configName" : "api_access",
+          "code" : "kb.ebsco.url",
+          "description" : "EBSCO RM-API URL",
+          "enabled" : true,
+          "value" : "https://sandbox.ebsco.io",
+          "metadata" : {
+            "createdDate" : "2017-12-12T14:06:19.499+0000",
+            "createdByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01",
+            "updatedDate" : "2017-12-12T14:06:19.499+0000",
+            "updatedByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01"
+          }
         } ],
-        "totalRecords" : 1,
+        "totalRecords" : 2,
         "resultInfo" : {
-          "totalRecords" : 1,
+          "totalRecords" : 2,
           "facets" : [ ]
         }
       },

--- a/src/test/resources/RMAPIConfiguration/mock_content_fail_missing_url.json
+++ b/src/test/resources/RMAPIConfiguration/mock_content_fail_missing_url.json
@@ -2,18 +2,32 @@
   "mocks": [
     {
       "description": "Missing customer ID RM API Configuration",
-      "url": "/configurations/entries?query=%28module%3D%3DKB_EBSCO%20AND%20configName%3D%3Dapi_credentials%29",
+      "url": "/configurations/entries?query=%28module%3D%3DEKB%20AND%20configName%3D%3Dapi_access%29",
       "method": "get",
       "status": 200,
       "receivedData": {
         "configs" : [ {
           "id" : "ca841444-70c0-429a-9ff4-c6e3daeae324",
-          "module" : "KB_EBSCO",
-          "configName" : "api_credentials",
-          "code" : "kb.ebsco.credentials",
+          "module" : "EKB",
+          "configName" : "api_access",
+          "code" : "kb.ebsco.customerId",
           "description" : "EBSCO RM-API Credentials",
           "enabled" : true,
-          "value" : "customer-id=examplecorp&api-key=8675309",
+          "value" : "examplecorp",
+          "metadata" : {
+            "createdDate" : "2017-11-29T18:39:15.182+0000",
+            "createdByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01",
+            "updatedDate" : "2017-11-29T18:39:15.182+0000",
+            "updatedByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01"
+          }
+        }, {
+          "id" : "ca841444-70c0-429a-9ff4-c6e3daeae325",
+          "module" : "EKB",
+          "configName" : "api_access",
+          "code" : "kb.ebsco.apiKey",
+          "description" : "EBSCO RM-API Credentials",
+          "enabled" : true,
+          "value" : "8675309",
           "metadata" : {
             "createdDate" : "2017-11-29T18:39:15.182+0000",
             "createdByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01",
@@ -21,9 +35,9 @@
             "updatedByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01"
           }
         } ],
-        "totalRecords" : 1,
+        "totalRecords" : 2,
         "resultInfo" : {
-          "totalRecords" : 1,
+          "totalRecords" : 2,
           "facets" : [ ]
         }
       },

--- a/src/test/resources/RMAPIConfiguration/mock_content_success.json
+++ b/src/test/resources/RMAPIConfiguration/mock_content_success.json
@@ -2,18 +2,32 @@
   "mocks": [
     {
       "description": "RM API Configuration",
-      "url": "/configurations/entries?query=%28module%3D%3DKB_EBSCO%20AND%20configName%3D%3Dapi_credentials%29",
+      "url": "/configurations/entries?query=%28module%3D%3DEKB%20AND%20configName%3D%3Dapi_access%29",
       "method": "get",
       "status": 200,
       "receivedData": {
         "configs" : [ {
           "id" : "ca841444-70c0-429a-9ff4-c6e3daeae324",
-          "module" : "KB_EBSCO",
-          "configName" : "api_credentials",
-          "code" : "kb.ebsco.credentials",
+          "module" : "EKB",
+          "configName" : "api_access",
+          "code" : "kb.ebsco.customerId",
           "description" : "EBSCO RM-API Credentials",
           "enabled" : true,
-          "value" : "customer-id=examplecorp&api-key=8675309",
+          "value" : "examplecorp",
+          "metadata" : {
+            "createdDate" : "2017-11-29T18:39:15.182+0000",
+            "createdByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01",
+            "updatedDate" : "2017-11-29T18:39:15.182+0000",
+            "updatedByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01"
+          }
+        }, {
+          "id" : "ca841444-70c0-429a-9ff4-c6e3daeae325",
+          "module" : "EKB",
+          "configName" : "api_access",
+          "code" : "kb.ebsco.apiKey",
+          "description" : "EBSCO RM-API Credentials",
+          "enabled" : true,
+          "value" : "8675309",
           "metadata" : {
             "createdDate" : "2017-11-29T18:39:15.182+0000",
             "createdByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01",
@@ -22,8 +36,8 @@
           }
         }, {
           "id" : "c1690a96-a138-4fb4-a3f0-deae960b2261",
-          "module" : "KB_EBSCO",
-          "configName" : "api_credentials",
+          "module" : "EKB",
+          "configName" : "api_access",
           "code" : "kb.ebsco.url",
           "description" : "EBSCO RM-API URL",
           "enabled" : true,
@@ -35,9 +49,9 @@
             "updatedByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01"
           }
         } ],
-        "totalRecords" : 2,
+        "totalRecords" : 3,
         "resultInfo" : {
-          "totalRecords" : 2,
+          "totalRecords" : 3,
           "facets" : [ ]
         }
       },

--- a/src/test/resources/RMAPIConfiguration/mock_content_success_multiple.json
+++ b/src/test/resources/RMAPIConfiguration/mock_content_success_multiple.json
@@ -2,18 +2,32 @@
   "mocks": [
     {
       "description": "RM API Configuration",
-      "url": "/configurations/entries?query=%28module%3D%3DKB_EBSCO%20AND%20configName%3D%3Dapi_credentials%29",
+      "url": "/configurations/entries?query=%28module%3D%3DEKB%20AND%20configName%3D%3Dapi_access%29",
       "method": "get",
       "status": 200,
       "receivedData": {
         "configs" : [ {
-          "id" : "ca841444-70c0-429a-9ff4-c6e3daeae325",
-          "module" : "KB_EBSCO",
-          "configName" : "api_credentials",
-          "code" : "kb.ebsco.credentials",
+          "id" : "ca841444-70c0-429a-9ff4-c6e3daeae335",
+          "module" : "EKB",
+          "configName" : "api_access",
+          "code" : "kb.ebsco.customerId",
           "description" : "EBSCO RM-API Credentials",
           "enabled" : true,
-          "value" : "customer-id=someexamplecorp&api-key=314159",
+          "value" : "someexamplecorp",
+          "metadata" : {
+            "createdDate" : "2017-11-29T19:39:15.182+0000",
+            "createdByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01",
+            "updatedDate" : "2017-11-29T19:39:15.182+0000",
+            "updatedByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01"
+          }
+        }, {
+          "id" : "ca841444-70c0-429a-9ff4-c6e3daeae334",
+          "module" : "EKB",
+          "configName" : "api_access",
+          "code" : "kb.ebsco.apiKey",
+          "description" : "EBSCO RM-API Credentials",
+          "enabled" : true,
+          "value" : "314159",
           "metadata" : {
             "createdDate" : "2017-11-29T19:39:15.182+0000",
             "createdByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01",
@@ -22,12 +36,26 @@
           }
         }, {
           "id" : "ca841444-70c0-429a-9ff4-c6e3daeae324",
-          "module" : "KB_EBSCO",
-          "configName" : "api_credentials",
-          "code" : "kb.ebsco.credentials",
+          "module" : "EKB",
+          "configName" : "api_access",
+          "code" : "kb.ebsco.customerId",
           "description" : "EBSCO RM-API Credentials",
           "enabled" : true,
-          "value" : "customer-id=examplecorp&api-key=8675309",
+          "value" : "examplecorp",
+          "metadata" : {
+            "createdDate" : "2017-11-29T18:39:15.182+0000",
+            "createdByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01",
+            "updatedDate" : "2017-11-29T18:39:15.182+0000",
+            "updatedByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01"
+          }
+        }, {
+          "id" : "ca841444-70c0-429a-9ff4-c6e3daeae325",
+          "module" : "EKB",
+          "configName" : "api_access",
+          "code" : "kb.ebsco.apiKey",
+          "description" : "EBSCO RM-API Credentials",
+          "enabled" : true,
+          "value" : "8675309",
           "metadata" : {
             "createdDate" : "2017-11-29T18:39:15.182+0000",
             "createdByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01",
@@ -63,9 +91,9 @@
             "updatedByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01"
           }
         } ],
-        "totalRecords" : 4,
+        "totalRecords" : 6,
         "resultInfo" : {
-          "totalRecords" : 4,
+          "totalRecords" : 6,
           "facets" : [ ]
         }
       },

--- a/src/test/resources/RMAPIConfiguration/mock_content_success_to_string.json
+++ b/src/test/resources/RMAPIConfiguration/mock_content_success_to_string.json
@@ -2,18 +2,32 @@
   "mocks": [
     {
       "description": "toString() RM API Configuration",
-      "url": "/configurations/entries?query=%28module%3D%3DKB_EBSCO%20AND%20configName%3D%3Dapi_credentials%29",
+      "url": "/configurations/entries?query=%28module%3D%3DEKB%20AND%20configName%3D%3Dapi_access%29",
       "method": "get",
       "status": 200,
       "receivedData": {
         "configs" : [ {
-          "id" : "ca841444-70c0-429a-9ff4-c6e3daeae324",
-          "module" : "KB_EBSCO",
-          "configName" : "api_credentials",
-          "code" : "kb.ebsco.credentials",
+          "id" : "ca841444-70c0-429a-9ff4-c6e3daeae325",
+          "module" : "EKB",
+          "configName" : "api_access",
+          "code" : "kb.ebsco.customerId",
           "description" : "EBSCO RM-API Credentials",
           "enabled" : true,
-          "value" : "customer-id=myid&api-key=mykey",
+          "value" : "myid",
+          "metadata" : {
+            "createdDate" : "2017-11-29T18:39:15.182+0000",
+            "createdByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01",
+            "updatedDate" : "2017-11-29T18:39:15.182+0000",
+            "updatedByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01"
+          }
+        }, {
+          "id" : "ca841444-70c0-429a-9ff4-c6e3daeae324",
+          "module" : "EKB",
+          "configName" : "api_access",
+          "code" : "kb.ebsco.apiKey",
+          "description" : "EBSCO RM-API Credentials",
+          "enabled" : true,
+          "value" : "mykey",
           "metadata" : {
             "createdDate" : "2017-11-29T18:39:15.182+0000",
             "createdByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01",
@@ -35,9 +49,9 @@
             "updatedByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01"
           }
         } ],
-        "totalRecords" : 2,
+        "totalRecords" : 3,
         "resultInfo" : {
-          "totalRecords" : 2,
+          "totalRecords" : 3,
           "facets" : [ ]
         }
       },


### PR DESCRIPTION
## Purpose
Fix for MODCXEKB-41

## Approach
Created a new mod-configuration module and configName (EKB and
api_access) for use by mod-codex-ekb and, in the future, mod-kb-ebsco.
Split the existing credentials entry (which was
customer-id=val&api-key=val) into two separate entries identified by the
codes kb.ebsco.customerId and kb.ebsco.apiKey. This change has
simplified the code quite a bit.

Updated the unit tests and the credential setting script to reflect
these changes.
