### PR TITLE
Update selected to match the updated json schema

### DIFF
--- a/src/main/java/org/folio/cql2rmapi/CQLParserForRMAPI.java
+++ b/src/main/java/org/folio/cql2rmapi/CQLParserForRMAPI.java
@@ -30,7 +30,7 @@ public class CQLParserForRMAPI {
   private static final String CQL_ALL_RECORDS = "cql.allRecords";
   private static final String RM_API_TITLE = "titlename";
   private static final String SOURCE = "source";
-  private static final String SELECTED = "selected";
+  private static final String SELECTED = "ext.selected";
   private static final String TITLE = "title";
   private static final String TYPE = "type";
 
@@ -287,7 +287,7 @@ public class CQLParserForRMAPI {
           break;
         case "true":
           builder.append(queryParam);
-          builder.append(SELECTED);
+          builder.append("selected");
           break;
         case "false":
           builder.append(queryParam);

--- a/src/test/java/org/folio/cql2rmapi/CQLParserForRMAPITest.java
+++ b/src/test/java/org/folio/cql2rmapi/CQLParserForRMAPITest.java
@@ -264,7 +264,7 @@ public class CQLParserForRMAPITest {
 
   @Test
   public void CQLParserReturnsExpectedQueriesIfSelectionIsSetToTrueTest() throws QueryValidationException, UnsupportedEncodingException {
-    final CQLParserForRMAPI parser = new CQLParserForRMAPI("title=bridget and type = journal and selected=true" , 900, 100);
+    final CQLParserForRMAPI parser = new CQLParserForRMAPI("title=bridget and type = journal and ext.selected=true" , 900, 100);
     final ArrayList<String> queries = (ArrayList<String>) parser.getRMAPIQueries();
     assertEquals(1, queries.size());
     assertEquals(0, parser.getInstanceIndex());
@@ -275,7 +275,7 @@ public class CQLParserForRMAPITest {
 
   @Test
   public void CQLParserReturnsExpectedQueriesIfSelectionIsSetToAllTest() throws QueryValidationException, UnsupportedEncodingException {
-    final CQLParserForRMAPI parser = new CQLParserForRMAPI("title=bridget and type = journal and selected=all" , 900, 100);
+    final CQLParserForRMAPI parser = new CQLParserForRMAPI("title=bridget and type = journal and ext.selected=all" , 900, 100);
     final ArrayList<String> queries = (ArrayList<String>) parser.getRMAPIQueries();
     assertEquals(1, queries.size());
     assertEquals(0, parser.getInstanceIndex());
@@ -286,7 +286,7 @@ public class CQLParserForRMAPITest {
 
   @Test
   public void CQLParserReturnsExpectedQueriesIfSelectionIsSetToFalseTest() throws QueryValidationException, UnsupportedEncodingException {
-    final CQLParserForRMAPI parser = new CQLParserForRMAPI("title=bridget and type = journal and selected=false" , 900, 100);
+    final CQLParserForRMAPI parser = new CQLParserForRMAPI("title=bridget and type = journal and ext.selected=false" , 900, 100);
     final ArrayList<String> queries = (ArrayList<String>) parser.getRMAPIQueries();
     assertEquals(1, queries.size());
     assertEquals(0, parser.getInstanceIndex());


### PR DESCRIPTION
## Purpose
JSON schema for selected index has been moved into an extension file https://github.com/folio-org/raml/blob/master/schemas/codex/codex_instance_cqlschema-ext.json and per documentation, ext.selected is preferred over selected

## Approach
_How does this change fulfill the purpose?_

#### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.

## Learning
_Describe the research stage. Add links to blog posts, patterns, libraries or addons used to solve this problem._
