### PR TITLE
Support prefix.index in CQL search based on new json schema

### DIFF
--- a/src/test/java/org/folio/cql2rmapi/CQLParserForRMAPITest.java
+++ b/src/test/java/org/folio/cql2rmapi/CQLParserForRMAPITest.java
@@ -294,4 +294,63 @@ public class CQLParserForRMAPITest {
       assertEquals("search=bridget&searchfield=titlename&resourcetype=journal&selection=notselected&orderby=titlename&count=100&offset=10", query);
     }
   }
+
+  @Test(expected = QueryValidationException.class)
+  public void CQLParserThrowsExceptionIfSelectionIsInvalidTest() throws QueryValidationException, UnsupportedEncodingException {
+    new CQLParserForRMAPI("title=bridget and type = journal and ext.selected=yes" , 900, 100);
+  }
+
+  @Test(expected = QueryValidationException.class)
+  public void CQLParserThrowsExceptionIfAllRecordsAreRequestedTest() throws QueryValidationException, UnsupportedEncodingException {
+    new CQLParserForRMAPI("query=cql.allrecords" , 900, 100);
+  }
+
+  @Test
+  public void CQLParserReturnsExpectedQueriesIfCodexTitleIsPassedTest() throws QueryValidationException, UnsupportedEncodingException {
+    final CQLParserForRMAPI parser = new CQLParserForRMAPI("codex.title=bridget and type = journal and ext.selected=false" , 900, 100);
+    final ArrayList<String> queries = (ArrayList<String>) parser.getRMAPIQueries();
+    assertEquals(1, queries.size());
+    assertEquals(0, parser.getInstanceIndex());
+    for (final String query: queries) {
+      assertEquals("search=bridget&searchfield=titlename&resourcetype=journal&selection=notselected&orderby=titlename&count=100&offset=10", query);
+    }
+  }
+
+  @Test
+  public void CQLParserReturnsExpectedQueriesIfCodexIdentifierIsPassedTest() throws QueryValidationException, UnsupportedEncodingException {
+    final CQLParserForRMAPI parser = new CQLParserForRMAPI("codex.identifier=12345 and type = journal and ext.selected=false" , 900, 100);
+    final ArrayList<String> queries = (ArrayList<String>) parser.getRMAPIQueries();
+    assertEquals(1, queries.size());
+    assertEquals(0, parser.getInstanceIndex());
+    for (final String query: queries) {
+      assertEquals("search=12345&searchfield=isxn&resourcetype=journal&selection=notselected&orderby=titlename&count=100&offset=10", query);
+    }
+  }
+
+  @Test
+  public void CQLParserReturnsExpectedQueriesIfCodexPublisherIsPassedTest() throws QueryValidationException, UnsupportedEncodingException {
+    final CQLParserForRMAPI parser = new CQLParserForRMAPI("codex.publisher=ebsco and type = journal and ext.selected=false" , 900, 100);
+    final ArrayList<String> queries = (ArrayList<String>) parser.getRMAPIQueries();
+    assertEquals(1, queries.size());
+    assertEquals(0, parser.getInstanceIndex());
+    for (final String query: queries) {
+      assertEquals("search=ebsco&searchfield=publisher&resourcetype=journal&selection=notselected&orderby=titlename&count=100&offset=10", query);
+    }
+  }
+
+  @Test
+  public void CQLParserReturnsExpectedQueriesIfPublisherIsPassedTest() throws QueryValidationException, UnsupportedEncodingException {
+    final CQLParserForRMAPI parser = new CQLParserForRMAPI("publisher=ebsco and type = journal and ext.selected=false" , 900, 100);
+    final ArrayList<String> queries = (ArrayList<String>) parser.getRMAPIQueries();
+    assertEquals(1, queries.size());
+    assertEquals(0, parser.getInstanceIndex());
+    for (final String query: queries) {
+      assertEquals("search=ebsco&searchfield=publisher&resourcetype=journal&selection=notselected&orderby=titlename&count=100&offset=10", query);
+    }
+  }
+
+  @Test(expected = QueryValidationException.class)
+  public void CQLParserThrowsExceptionIfInvalidSearchFieldWithPrefixIsPassedTest() throws QueryValidationException, UnsupportedEncodingException {
+    new CQLParserForRMAPI("codex.type=12345" , 900, 100);
+  }
 }


### PR DESCRIPTION
## Purpose
Per the changes to codex json schema, add support for prefix of the schema.index for example: codex.title and title, codex.identifier and identifier, codex.publisher and publisher are now supported in search. 
This change also consists its associated unit tests.

## Approach
_How does this change fulfill the purpose?_

#### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.

## Learning
_Describe the research stage. Add links to blog posts, patterns, libraries or addons used to solve this problem._
