### PR TITLE
Understanding pact: MODCXEKB-8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -117,6 +117,24 @@
       <artifactId>vertx-unit</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>au.com.dius</groupId>
+      <artifactId>pact-jvm-consumer-junit_2.12</artifactId>
+      <version>3.5.10</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>au.com.dius</groupId>
+      <artifactId>pact-jvm-consumer-java8_2.12</artifactId>
+      <version>3.5.10</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.rest-assured</groupId>
+      <artifactId>rest-assured</artifactId>
+      <version>3.0.6</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/src/test/java/org/folio/pact/ModConfigurationPactTest.java
+++ b/src/test/java/org/folio/pact/ModConfigurationPactTest.java
@@ -1,0 +1,60 @@
+package org.folio.pact;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasItems;
+
+import java.io.IOException;
+
+import org.apache.commons.io.IOUtils;
+import org.junit.Rule;
+import org.junit.Test;
+
+import au.com.dius.pact.consumer.Pact;
+import au.com.dius.pact.consumer.PactProviderRuleMk2;
+import au.com.dius.pact.consumer.PactVerification;
+import au.com.dius.pact.consumer.dsl.PactDslWithProvider;
+import au.com.dius.pact.model.RequestResponsePact;
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+
+/**
+ * @author mreno
+ *
+ */
+public class ModConfigurationPactTest {
+  private static final String MOD_CONFIGURATION_JSON_FILE = "pact/mod-configuration.json";
+
+  @Rule
+  public PactProviderRuleMk2 mockProvider = new PactProviderRuleMk2("mod-configuration", this);
+
+  @Pact(provider="mod-configuration", consumer="mod-codex-ekb")
+  public RequestResponsePact createPact(PactDslWithProvider builder) throws IOException {
+    final String body = IOUtils.toString(ModConfigurationPactTest.class.getClassLoader().getResourceAsStream(MOD_CONFIGURATION_JSON_FILE));
+    return builder
+        .given("configuration needed")
+        .uponReceiving("RM API Configuration")
+          .path("/configurations/entries")
+          .query("query=%28module%3D%3DEKB%20AND%20configName%3D%3Dapi_access%29")
+          .method("GET")
+        .willRespondWith()
+          .status(200)
+          .body(body, org.apache.http.entity.ContentType.APPLICATION_JSON)
+        .toPact();
+  }
+
+  @Test
+  @PactVerification("mod-configuration")
+  public void test() {
+    RestAssured
+      .given()
+        .port(mockProvider.getPort().intValue())
+      .when()
+        .get("/configurations/entries?query=%28module%3D%3DEKB%20AND%20configName%3D%3Dapi_access%29")
+      .then()
+        .statusCode(200)
+        .contentType(ContentType.JSON)
+        .body("totalRecords", equalTo(3),
+            "configs.code", hasItems("kb.ebsco.customerId", "kb.ebsco.apiKey", "kb.ebsco.url"),
+            "configs.value", hasItems("examplecorp", "8675309", "https://rmapi.example.com"));
+  }
+}

--- a/src/test/resources/pact/mod-configuration.json
+++ b/src/test/resources/pact/mod-configuration.json
@@ -1,0 +1,50 @@
+{
+  "configs" : [ {
+    "id" : "ca841444-70c0-429a-9ff4-c6e3daeae324",
+    "module" : "EKB",
+    "configName" : "api_access",
+    "code" : "kb.ebsco.customerId",
+    "description" : "EBSCO RM-API Credentials",
+    "enabled" : true,
+    "value" : "examplecorp",
+    "metadata" : {
+      "createdDate" : "2017-11-29T18:39:15.182+0000",
+      "createdByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01",
+      "updatedDate" : "2017-11-29T18:39:15.182+0000",
+      "updatedByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01"
+    }
+  }, {
+    "id" : "ca841444-70c0-429a-9ff4-c6e3daeae325",
+    "module" : "EKB",
+    "configName" : "api_access",
+    "code" : "kb.ebsco.apiKey",
+    "description" : "EBSCO RM-API Credentials",
+    "enabled" : true,
+    "value" : "8675309",
+    "metadata" : {
+      "createdDate" : "2017-11-29T18:39:15.182+0000",
+      "createdByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01",
+      "updatedDate" : "2017-11-29T18:39:15.182+0000",
+      "updatedByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01"
+    }
+  }, {
+    "id" : "c1690a96-a138-4fb4-a3f0-deae960b2261",
+    "module" : "EKB",
+    "configName" : "api_access",
+    "code" : "kb.ebsco.url",
+    "description" : "EBSCO RM-API URL",
+    "enabled" : true,
+    "value" : "https://rmapi.example.com",
+    "metadata" : {
+      "createdDate" : "2017-12-08T15:11:52.562+0000",
+      "createdByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01",
+      "updatedDate" : "2017-12-08T15:11:52.562+0000",
+      "updatedByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01"
+    }
+  } ],
+  "totalRecords" : 3,
+  "resultInfo" : {
+    "totalRecords" : 3,
+    "facets" : [ ]
+  }
+}


### PR DESCRIPTION
## Purpose
Investigate PACT and how we can use it.

## Approach
Created a basic PACT test for mod-codex-ekb's use of mod-configuration. The pact file is stored in target/pacts. This file would likely need to be stored in a PACT broker. Need to look into that.

#### TODOS and Open Questions
- [ ] Refine PACT test for mod-configuration.
- [ ] PACT test for RM API.
- [ ] Synthesize a consumer of mod-codex-ekb (mod-codex-mux?) and create a PACT file for build time verification.
- [ ] Store PACT files in a PACT broker (do we have one? If not, maybe: https://pact.dius.com.au).

## Learning
https://www.gitbook.com/book/pact-foundation/pact/details
https://github.com/DiUS/pact-jvm
https://github.com/DiUS/pact-jvm/tree/master/pact-jvm-consumer-junit
