### PR TITLE
switch to fabric8-based docker base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:8-jre
+FROM folioci/openjdk8-jre:latest
 
 ENV VERTICLE_FILE mod-codex-ekb-fat.jar
 
@@ -6,23 +6,7 @@ ENV VERTICLE_FILE mod-codex-ekb-fat.jar
 ENV VERTICLE_HOME /usr/verticles
 
 # Copy your fat jar to the container
-COPY target/$VERTICLE_FILE $VERTICLE_HOME/module.jar
-COPY docker/docker-entrypoint.sh $VERTICLE_HOME/docker-entrypoint.sh
-
-# Create user/group 'folio'
-RUN groupadd folio && \
-    useradd -r -d $VERTICLE_HOME -g folio -M folio && \
-    chown -R folio.folio $VERTICLE_HOME && \
-    chown -R folio.folio ${VERTICLE_HOME}/docker-entrypoint.sh && \
-    chmod +x ${VERTICLE_HOME}/docker-entrypoint.sh
-
-# Run as this user
-USER folio
-
-# Launch the verticle
-WORKDIR $VERTICLE_HOME
+COPY target/${VERTICLE_FILE} ${VERTICLE_HOME}/${VERTICLE_FILE}
 
 # Expose this port locally in the container.
 EXPOSE 8081
-
-ENTRYPOINT ["./docker-entrypoint.sh"]


### PR DESCRIPTION
## Purpose
Dockerfile uses a new base image which adds remote JMX capabilities to the container as well as automatic JVM heap sizing based on container runtime resource configuration. 

## Approach
Modified  Dockerfile which uses a new base image. 

#### TODOS and Open Questions

## Learning
See https://github.com/folio-org/folio-tools/tree/master/folio-java-docker/openjdk8 for additional details. 