### PR TITLE
Fix tests that could have failures due to a bind exception

### DIFF
--- a/src/test/java/org/folio/codex/RMAPIToCodexTest.java
+++ b/src/test/java/org/folio/codex/RMAPIToCodexTest.java
@@ -7,7 +7,6 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Modifier;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Random;
 import java.util.concurrent.CompletionException;
 
 import org.folio.config.RMAPIConfiguration;
@@ -18,6 +17,7 @@ import org.folio.rest.jaxrs.model.Contributor;
 import org.folio.rest.jaxrs.model.Identifier;
 import org.folio.rest.jaxrs.model.Instance;
 import org.folio.rest.tools.client.test.HttpClientMock2;
+import org.folio.utils.Utils;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -45,9 +45,6 @@ public class RMAPIToCodexTest {
   private final Logger logger = LoggerFactory.getLogger("okapi");
 
   private Vertx vertx;
-  // Use a random ephemeral port if not defined via a system property
-  private final int port = Integer.parseInt(System.getProperty("port",
-      Integer.toString(new Random().nextInt(16_384) + 49_152)));
 
   private Map<String, String> okapiHeaders = new HashMap<>();
   // HACK ALERT! This object is needed to modify RMAPIConfiguration's local
@@ -59,6 +56,8 @@ public class RMAPIToCodexTest {
    */
   @Before
   public void setUp(TestContext context) throws Exception {
+    final int port = Utils.getRandomPort();
+
     vertx = Vertx.vertx();
 
     JsonObject conf = new JsonObject()

--- a/src/test/java/org/folio/config/RMAPIConfigurationTest.java
+++ b/src/test/java/org/folio/config/RMAPIConfigurationTest.java
@@ -3,11 +3,11 @@ package org.folio.config;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Random;
 import java.util.concurrent.CompletableFuture;
 
 import org.folio.rest.RestVerticle;
 import org.folio.rest.tools.client.test.HttpClientMock2;
+import org.folio.utils.Utils;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -56,9 +56,6 @@ public class RMAPIConfigurationTest {
   private static final String MOCK_CONTENT_FAIL_INTERNAL_ERROR_FILE = "RMAPIConfiguration/mock_content_fail_internal_error.json";
 
   private final Logger logger = LoggerFactory.getLogger("okapi");
-  // Use a random ephemeral port if not defined via a system property
-  private final int port = Integer.parseInt(System.getProperty("port",
-      Integer.toString(new Random().nextInt(16_384) + 49_152)));
 
   private Vertx vertx;
   private Map<String, String> okapiHeaders = new HashMap<>();
@@ -71,6 +68,8 @@ public class RMAPIConfigurationTest {
    */
   @Before
   public void setUp(TestContext context) throws Exception {
+    final int port = Utils.getRandomPort();
+
     vertx = Vertx.vertx();
 
     JsonObject conf = new JsonObject()

--- a/src/test/java/org/folio/utils/Utils.java
+++ b/src/test/java/org/folio/utils/Utils.java
@@ -1,0 +1,41 @@
+/**
+ *
+ */
+package org.folio.utils;
+
+import java.io.IOException;
+import java.net.ServerSocket;
+import java.util.Random;
+
+/**
+ * @author mreno
+ *
+ */
+public final class Utils {
+  private Utils() {
+    super();
+  }
+
+  /**
+   * Returns a random ephemeral port that has a high probability of not being
+   * in use.
+   *
+   * @return a random port number.
+   */
+  public static int getRandomPort() {
+    int port = -1;
+    do {
+      // Use a random ephemeral port if not defined via a system property
+      port = new Random().nextInt(16_384) + 49_152;
+      try {
+        ServerSocket socket = new ServerSocket(port);
+        socket.close();
+      } catch (IOException e) {
+        continue;
+      }
+      break;
+    } while (true);
+
+    return port;
+  }
+}


### PR DESCRIPTION
## Purpose
Reduce the possibility of test failures due to ports already being in use.

## Approach
Some tests use random ephemeral ports in the 49152-65535 range. The odds of a collision are low, but I have seen it happen occasionally in my dev environment. While we can't eliminate the problem, given how Vert.x is started (AFAICT), we can reduce the probability of using a bound port significantly by first trying to bind to the port. To this end, a utility class has been added that has a static method to retrieve random ports that have this high probability of not being in use. Tests that require random ports should use this utility method to acquire ports.

## Learning
http://vertx.io/blog/vert-x-application-configuration/