### PR TITLE
Update CQL Parser to align with RAML changes

### DIFF
--- a/src/main/java/org/folio/rest/impl/CodexInstancesResourceImpl.java
+++ b/src/main/java/org/folio/rest/impl/CodexInstancesResourceImpl.java
@@ -75,10 +75,8 @@ public final class CodexInstancesResourceImpl implements CodexInstancesResource 
       .thenCompose(rmAPIConfig ->
         RMAPIToCodex.getInstance(id, vertxContext, rmAPIConfig)
       ).thenApply(instance -> {
-        asyncResultHandler.handle(Future.succeededFuture(
-            instance == null ?
-                CodexInstancesResource.GetCodexInstancesByIdResponse.withPlainNotFound(id) :
-                  CodexInstancesResource.GetCodexInstancesByIdResponse.withJsonOK(instance)));
+        asyncResultHandler.handle(
+            Future.succeededFuture(CodexInstancesResource.GetCodexInstancesByIdResponse.withJsonOK(instance)));
         return instance;
       }).exceptionally(throwable -> {
         log.error("getCodexInstancesById failed!", throwable);

--- a/src/test/java/org/folio/cql2rmapi/CQLParserForRMAPITest.java
+++ b/src/test/java/org/folio/cql2rmapi/CQLParserForRMAPITest.java
@@ -3,6 +3,7 @@ package org.folio.cql2rmapi;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 
 import java.io.UnsupportedEncodingException;
 import java.util.ArrayList;
@@ -19,7 +20,7 @@ public class CQLParserForRMAPITest {
 
   private static final String VALID_QUERY = "title=bridget";
   private static final String VALID_ISBN_QUERY = "identifier = 12345 sortby title";
-  private static final String VALID_FILTER_QUERY = "title = bridget and type = video sortby title";
+  private static final String VALID_FILTER_QUERY = "title = bridget and resourceType = video sortby title";
 
   @Test(expected = QueryValidationException.class)
   public void initCQLParserThrowsExceptionIfQueryInvalidTest() throws QueryValidationException, UnsupportedEncodingException {
@@ -68,50 +69,50 @@ public class CQLParserForRMAPITest {
     assertEquals("titlename", parser.searchField);
     assertEquals("bridget", parser.searchValue);
     assertEquals("titlename", parser.sortType);
-    assertEquals("type", parser.filterType);
+    assertEquals("resourceType", parser.filterType);
     assertEquals("streamingvideo", parser.filterValue);
   }
 
   @Test(expected = QueryValidationException.class)
   public void CQLParserThrowsExceptionIfInvalidFilterValueIsPassedTest() throws QueryValidationException, UnsupportedEncodingException {
-    final String invalidFilterQuery = "title = bridget and type = hardcopy sortby title";
+    final String invalidFilterQuery = "title = bridget and resourceType = hardcopy sortby title";
     new CQLParserForRMAPI(invalidFilterQuery, 1, 10);
   }
 
   @Test(expected = QueryValidationException.class)
   public void CQLParserThrowsExceptionIfNullFilterValueIsPassedTest() throws QueryValidationException, UnsupportedEncodingException {
-    final String invalidFilterQuery = "title = bridget and type = null sortby title";
+    final String invalidFilterQuery = "title = bridget and resourceType = null sortby title";
     final CQLParserForRMAPI parser = new CQLParserForRMAPI(invalidFilterQuery, 1, 10);
     parser.filterValue = null;
   }
 
   @Test(expected = QueryValidationException.class)
   public void CQLParserThrowsExceptionIfMultipleFiltersSepartedByAndAreProvidedTest() throws QueryValidationException, UnsupportedEncodingException {
-    final String multipleFilterQuery = "title = bridget and type = databases and type = audiobook sortby title";
+    final String multipleFilterQuery = "title = bridget and resourceType = databases and type = audiobook sortby title";
     new CQLParserForRMAPI(multipleFilterQuery, 1, 10);
   }
 
   @Test(expected = QueryValidationException.class)
   public void CQLParserThrowsExceptionIfMultipleFiltersSepartedByCommaAreProvidedTest() throws QueryValidationException, UnsupportedEncodingException {
-    final String multipleFilterQuery = "title = bridget and type = databases, audiobook sortby title";
+    final String multipleFilterQuery = "title = bridget and resourceType = databases, audiobook sortby title";
     new CQLParserForRMAPI(multipleFilterQuery, 1, 10);
   }
 
   @Test(expected = QueryValidationException.class)
   public void CQLParserThrowsExceptionIfMultipleFiltersSepartedBySpaceAreProvidedTest() throws QueryValidationException, UnsupportedEncodingException {
-    final String multipleFilterQuery = "title = bridget and type = databases audiobook sortby title";
+    final String multipleFilterQuery = "title = bridget and resourceType = databases audiobook sortby title";
     new CQLParserForRMAPI(multipleFilterQuery, 1, 10);
   }
 
   @Test(expected = QueryValidationException.class)
   public void CQLParserThrowsExceptionIfMultipleSortKeysAreProvidedTest() throws QueryValidationException, UnsupportedEncodingException {
-    final String multipleSortQuery = "title = bridget and type = journal sortby title, publisher";
+    final String multipleSortQuery = "title = bridget and resourceType = journal sortby title, publisher";
     new CQLParserForRMAPI(multipleSortQuery, 1, 10);
   }
 
   @Test(expected = QueryValidationException.class)
   public void CQLParserThrowsExceptionIfSortOnUnsupportedFieldTest() throws QueryValidationException, UnsupportedEncodingException {
-    final String multipleSortQuery = "title = bridget and type = journal sortby publisher";
+    final String multipleSortQuery = "title = bridget and resourceType = journal sortby publisher";
     new CQLParserForRMAPI(multipleSortQuery, 1, 10);
   }
 
@@ -196,10 +197,10 @@ public class CQLParserForRMAPITest {
 
   @Test
   public void CQLParserSetsExpectedValuesInCaseOfValidSearchTest() throws UnsupportedEncodingException, QueryValidationException {
-    final CQLParserForRMAPI parser = new CQLParserForRMAPI("type=reports AND title=bridget" , 10, 10);
+    final CQLParserForRMAPI parser = new CQLParserForRMAPI("resourceType=reports AND title=bridget" , 10, 10);
     assertEquals("titlename", parser.searchField);
     assertEquals("bridget", parser.searchValue);
-    assertEquals("type", parser.filterType);
+    assertEquals("resourceType", parser.filterType);
     assertEquals("report", parser.filterValue);
   }
 
@@ -264,7 +265,7 @@ public class CQLParserForRMAPITest {
 
   @Test
   public void CQLParserReturnsExpectedQueriesIfSelectionIsSetToTrueTest() throws QueryValidationException, UnsupportedEncodingException {
-    final CQLParserForRMAPI parser = new CQLParserForRMAPI("title=bridget and type = video and ext.selected=true" , 900, 100);
+    final CQLParserForRMAPI parser = new CQLParserForRMAPI("title=bridget and resourceType = video and ext.selected=true" , 900, 100);
     final ArrayList<String> queries = (ArrayList<String>) parser.getRMAPIQueries();
     assertEquals(1, queries.size());
     assertEquals(0, parser.getInstanceIndex());
@@ -275,7 +276,7 @@ public class CQLParserForRMAPITest {
 
   @Test
   public void CQLParserReturnsExpectedQueriesIfSelectionIsSetToAllTest() throws QueryValidationException, UnsupportedEncodingException {
-    final CQLParserForRMAPI parser = new CQLParserForRMAPI("title=bridget and type = databases and ext.selected=all" , 900, 100);
+    final CQLParserForRMAPI parser = new CQLParserForRMAPI("title=bridget and resourceType = databases and ext.selected=all" , 900, 100);
     final ArrayList<String> queries = (ArrayList<String>) parser.getRMAPIQueries();
     assertEquals(1, queries.size());
     assertEquals(0, parser.getInstanceIndex());
@@ -286,7 +287,7 @@ public class CQLParserForRMAPITest {
 
   @Test
   public void CQLParserReturnsExpectedQueriesIfSelectionIsSetToFalseTest() throws QueryValidationException, UnsupportedEncodingException {
-    final CQLParserForRMAPI parser = new CQLParserForRMAPI("title=bridget and type = video and ext.selected=false" , 900, 100);
+    final CQLParserForRMAPI parser = new CQLParserForRMAPI("title=bridget and resourceType = video and ext.selected=false" , 900, 100);
     final ArrayList<String> queries = (ArrayList<String>) parser.getRMAPIQueries();
     assertEquals(1, queries.size());
     assertEquals(0, parser.getInstanceIndex());
@@ -297,7 +298,7 @@ public class CQLParserForRMAPITest {
 
   @Test(expected = QueryValidationException.class)
   public void CQLParserThrowsExceptionIfSelectionIsInvalidTest() throws QueryValidationException, UnsupportedEncodingException {
-    new CQLParserForRMAPI("title=bridget and type = databases and ext.selected=yes" , 900, 100);
+    new CQLParserForRMAPI("title=bridget and resourceType = databases and ext.selected=yes" , 900, 100);
   }
 
   @Test(expected = QueryValidationException.class)
@@ -307,7 +308,7 @@ public class CQLParserForRMAPITest {
 
   @Test
   public void CQLParserReturnsExpectedQueriesIfCodexTitleIsPassedTest() throws QueryValidationException, UnsupportedEncodingException {
-    final CQLParserForRMAPI parser = new CQLParserForRMAPI("codex.title=bridget and type = audiobooks and ext.selected=false" , 900, 100);
+    final CQLParserForRMAPI parser = new CQLParserForRMAPI("codex.title=bridget and resourceType = audiobooks and ext.selected=false" , 900, 100);
     final ArrayList<String> queries = (ArrayList<String>) parser.getRMAPIQueries();
     assertEquals(1, queries.size());
     assertEquals(0, parser.getInstanceIndex());
@@ -318,7 +319,7 @@ public class CQLParserForRMAPITest {
 
   @Test
   public void CQLParserReturnsExpectedQueriesIfCodexIdentifierIsPassedTest() throws QueryValidationException, UnsupportedEncodingException {
-    final CQLParserForRMAPI parser = new CQLParserForRMAPI("codex.identifier=12345 and type = databases and ext.selected=false" , 900, 100);
+    final CQLParserForRMAPI parser = new CQLParserForRMAPI("codex.identifier=12345 and resourceType = databases and ext.selected=false" , 900, 100);
     final ArrayList<String> queries = (ArrayList<String>) parser.getRMAPIQueries();
     assertEquals(1, queries.size());
     assertEquals(0, parser.getInstanceIndex());
@@ -329,7 +330,7 @@ public class CQLParserForRMAPITest {
 
   @Test
   public void CQLParserReturnsExpectedQueriesIfCodexPublisherIsPassedTest() throws QueryValidationException, UnsupportedEncodingException {
-    final CQLParserForRMAPI parser = new CQLParserForRMAPI("codex.publisher=ebsco and type = databases and ext.selected=false" , 900, 100);
+    final CQLParserForRMAPI parser = new CQLParserForRMAPI("codex.publisher=ebsco and resourceType = databases and ext.selected=false" , 900, 100);
     final ArrayList<String> queries = (ArrayList<String>) parser.getRMAPIQueries();
     assertEquals(1, queries.size());
     assertEquals(0, parser.getInstanceIndex());
@@ -340,7 +341,7 @@ public class CQLParserForRMAPITest {
 
   @Test
   public void CQLParserReturnsExpectedQueriesIfPublisherIsPassedTest() throws QueryValidationException, UnsupportedEncodingException {
-    final CQLParserForRMAPI parser = new CQLParserForRMAPI("publisher=ebsco and type = video and ext.selected=false" , 900, 100);
+    final CQLParserForRMAPI parser = new CQLParserForRMAPI("publisher=ebsco and resourceType = video and ext.selected=false" , 900, 100);
     final ArrayList<String> queries = (ArrayList<String>) parser.getRMAPIQueries();
     assertEquals(1, queries.size());
     assertEquals(0, parser.getInstanceIndex());
@@ -351,6 +352,13 @@ public class CQLParserForRMAPITest {
 
   @Test(expected = QueryValidationException.class)
   public void CQLParserThrowsExceptionIfInvalidSearchFieldWithPrefixIsPassedTest() throws QueryValidationException, UnsupportedEncodingException {
-    new CQLParserForRMAPI("codex.type=12345" , 900, 100);
+    new CQLParserForRMAPI("codex.resourceType=12345" , 900, 100);
+  }
+
+  @Test
+  public void CQLParserReturnsCorrectIdValueIfPassed() throws UnsupportedEncodingException, QueryValidationException {
+    final CQLParserForRMAPI parser = new CQLParserForRMAPI("id=12345" , 0, 1);
+    assertTrue(parser.isIDSearchField());
+    assertEquals("12345", parser.getID());
   }
 }


### PR DESCRIPTION
## Purpose
- Parse resourceType instead of type
- Parse id as a search string
- Associated tests
- Cleanup unreachable code in Impl class

## Approach
_How does this change fulfill the purpose?_

#### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.

## Learning
_Describe the research stage. Add links to blog posts, patterns, libraries or addons used to solve this problem._
