### PR TITLE
Implement MODCXEKB-52 - Search by ID

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,2 +1,5 @@
+## 0.0.2 2018-01-04
+ * Support instance search by ID - MODCXEKB-51 / MODCXEKB-52
+ 
 ## 0.0.1 2017-11-16
  * Initial work

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.folio</groupId>
   <artifactId>mod-codex-ekb</artifactId>
-  <version>0.0.1-SNAPSHOT</version>
+  <version>0.0.2-SNAPSHOT</version>
 
   <name>EBSCO Knowledge Base Codex Module</name>
   <url>https://github.com/folio-org/mod-codex-ekb</url>

--- a/src/test/java/org/folio/codex/RMAPIToCodexTest.java
+++ b/src/test/java/org/folio/codex/RMAPIToCodexTest.java
@@ -1,5 +1,7 @@
 package org.folio.codex;
 
+import static org.folio.utils.Utils.readMockFile;
+
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.lang.reflect.Constructor;
@@ -42,6 +44,7 @@ import io.vertx.ext.unit.junit.VertxUnitRunner;
 @RunWith(VertxUnitRunner.class)
 public class RMAPIToCodexTest {
   private static final String MOCK_CONTENT_FILE = "RMAPIToCodex/mock_content.json";
+  private static final String MOCK_RMAPI_INSTANCE_TITLE_404_FILE = "RMAPIService/TitleNotFound.json";
 
   private final Logger logger = LoggerFactory.getLogger("okapi");
 
@@ -99,6 +102,8 @@ public class RMAPIToCodexTest {
         req.response().setStatusCode(200).end("{\"titleId\":4581057,\"titleName\":\"The World According to Philip K. Dick\",\"publisherName\":\"Palgrave Macmillan Ltd.\",\"identifiersList\":[{\"id\":\"3114209\",\"source\":\"AtoZ\",\"subtype\":0,\"type\":9},{\"id\":\"978-1-137-41458-8\",\"source\":\"ResourceIdentifier\",\"subtype\":9,\"type\":1},{\"id\":\"978-1-137-41459-5\",\"source\":\"ResourceIdentifier\",\"subtype\":2,\"type\":1},{\"id\":\"978-1-349-49032-5\",\"source\":\"ResourceIdentifier\",\"subtype\":1,\"type\":1},{\"id\":\"998217\",\"source\":\"ResourceIdentifier\",\"subtype\":0,\"type\":7}],\"subjectsList\":[{\"type\":\"BISAC\",\"subject\":\"LITERARY CRITICISM / Science Fiction & Fantasy\"}],\"isTitleCustom\":false,\"pubType\":\"Book\",\"customerResourcesList\":[{\"titleId\":4581052,\"packageId\":3814,\"packageName\":\"Palgrave Connect Literature & Performing Arts eBook Collection\",\"packageType\":\"Complete\",\"proxy\":{\"id\":\"<n>\",\"inherited\":true},\"isPackageCustom\":false,\"vendorId\":262,\"vendorName\":\"Palgrave Macmillan Ltd\",\"locationId\":16869169,\"isSelected\":false,\"isTokenNeeded\":false,\"visibilityData\":{\"isHidden\":false,\"reason\":\"\"},\"managedCoverageList\":[{\"beginCoverage\":\"2015-01-01\",\"endCoverage\":\"2015-12-31\"}],\"customCoverageList\":[],\"coverageStatement\":null,\"managedEmbargoPeriod\":{\"embargoUnit\":null,\"embargoValue\":0},\"customEmbargoPeriod\":{\"embargoUnit\":null,\"embargoValue\":0},\"url\":\"http://www.palgraveconnect.com/pc/doifinder/10.1057/9781137414595\",\"userDefinedField1\":null,\"userDefinedField2\":null,\"userDefinedField3\":null,\"userDefinedField4\":null,\"userDefinedField5\":null},{\"titleId\":4581052,\"packageId\":3831,\"packageName\":\"Palgrave Connect Complete eBook Collection\",\"packageType\":\"Variable\",\"proxy\":{\"id\":\"<n>\",\"inherited\":true},\"isPackageCustom\":false,\"vendorId\":262,\"vendorName\":\"Palgrave Macmillan Ltd\",\"locationId\":12282411,\"isSelected\":false,\"isTokenNeeded\":false,\"visibilityData\":{\"isHidden\":false,\"reason\":\"\"},\"managedCoverageList\":[{\"beginCoverage\":\"2015-01-01\",\"endCoverage\":\"2015-12-31\"}],\"customCoverageList\":[],\"coverageStatement\":null,\"managedEmbargoPeriod\":{\"embargoUnit\":null,\"embargoValue\":0},\"customEmbargoPeriod\":{\"embargoUnit\":null,\"embargoValue\":0},\"url\":\"http://www.palgraveconnect.com/pc/doifinder/10.1057/9781137414595\",\"userDefinedField1\":null,\"userDefinedField2\":null,\"userDefinedField3\":null,\"userDefinedField4\":null,\"userDefinedField5\":null},{\"titleId\":4581052,\"packageId\":5207,\"packageName\":\"EBSCO eBooks\",\"packageType\":\"Selectable\",\"proxy\":{\"id\":\"proxy-id-123\",\"inherited\":true},\"isPackageCustom\":false,\"vendorId\":19,\"vendorName\":\"EBSCO\",\"locationId\":12699213,\"isSelected\":false,\"isTokenNeeded\":false,\"visibilityData\":{\"isHidden\":false,\"reason\":\"\"},\"managedCoverageList\":[{\"beginCoverage\":\"2015-01-01\",\"endCoverage\":\"2015-12-31\"}],\"customCoverageList\":[],\"coverageStatement\":null,\"managedEmbargoPeriod\":{\"embargoUnit\":null,\"embargoValue\":0},\"customEmbargoPeriod\":{\"embargoUnit\":null,\"embargoValue\":0},\"url\":\"http://search.ebscohost.com/login.aspx?direct=true&scope=site&db=nlebk&db=nlabk&AN=998217\",\"userDefinedField1\":null,\"userDefinedField2\":null,\"userDefinedField3\":null,\"userDefinedField4\":null,\"userDefinedField5\":null},{\"titleId\":4581052,\"packageId\":1244867,\"packageName\":\"Palgrave Connect Literature eBook Collection 2015\",\"packageType\":\"Complete\",\"proxy\":{\"id\":\"<n>\",\"inherited\":true},\"isPackageCustom\":false,\"vendorId\":262,\"vendorName\":\"Palgrave Macmillan Ltd\",\"locationId\":16870606,\"isSelected\":false,\"isTokenNeeded\":false,\"visibilityData\":{\"isHidden\":false,\"reason\":\"\"},\"managedCoverageList\":[{\"beginCoverage\":\"2015-01-01\",\"endCoverage\":\"2015-12-31\"}],\"customCoverageList\":[],\"coverageStatement\":null,\"managedEmbargoPeriod\":{\"embargoUnit\":null,\"embargoValue\":0},\"customEmbargoPeriod\":{\"embargoUnit\":null,\"embargoValue\":0},\"url\":\"http://www.palgraveconnect.com/pc/doifinder/10.1057/9781137414595\",\"userDefinedField1\":null,\"userDefinedField2\":null,\"userDefinedField3\":null,\"userDefinedField4\":null,\"userDefinedField5\":null}],\"description\":null,\"edition\":null,\"isPeerReviewed\":false,\"contributorsList\":[{\"type\":\"editor\",\"contributor\":\"Stefan Schlensag\"},{\"type\":\"editor\",\"contributor\":\"Alexander Dunst\"},{\"type\":\"author\",\"contributor\":\"Dunst, Alexander\"},{\"type\":\"author\",\"contributor\":\"Schlensag, Stefan\"}]}");
       } else if (req.path().equals("/rm/rmaccounts/test/titles/2619585")) {
         req.response().setStatusCode(200).end("{\"titleId\":2619585,\"titleName\":\"Tom, Dick and Harry\",\"publisherName\":\"Project Gutenberg Literary Archive Foundation\",\"identifiersList\":[],\"subjectsList\":[],\"isTitleCustom\":false,\"pubType\":\"Book\",\"customerResourcesList\":[{\"titleId\":1619585,\"packageId\":6750,\"packageName\":\"Project Gutenberg eBooks\",\"packageType\":\"Variable\",\"proxy\":{\"id\":\"<n>\",\"inherited\":true},\"isPackageCustom\":false,\"vendorId\":953,\"vendorName\":\"Project Gutenberg\",\"locationId\":5137360,\"isSelected\":false,\"isTokenNeeded\":false,\"visibilityData\":{\"isHidden\":false,\"reason\":\"\"},\"managedCoverageList\":[],\"customCoverageList\":[],\"coverageStatement\":null,\"managedEmbargoPeriod\":{\"embargoUnit\":null,\"embargoValue\":0},\"customEmbargoPeriod\":{\"embargoUnit\":null,\"embargoValue\":0},\"url\":\"http://www.gutenberg.org/ebooks/20992\",\"userDefinedField1\":null,\"userDefinedField2\":null,\"userDefinedField3\":null,\"userDefinedField4\":null,\"userDefinedField5\":null},{\"titleId\":1619585,\"packageId\":19153,\"packageName\":\"Project Gutenberg eBooks Archive Collection\",\"packageType\":\"Variable\",\"proxy\":{\"id\":\"<n>\",\"inherited\":true},\"isPackageCustom\":false,\"vendorId\":953,\"vendorName\":\"Project Gutenberg\",\"locationId\":7435416,\"isSelected\":false,\"isTokenNeeded\":false,\"visibilityData\":{\"isHidden\":false,\"reason\":\"\"},\"managedCoverageList\":[],\"customCoverageList\":[],\"coverageStatement\":null,\"managedEmbargoPeriod\":{\"embargoUnit\":null,\"embargoValue\":0},\"customEmbargoPeriod\":{\"embargoUnit\":null,\"embargoValue\":0},\"url\":\"https://archive.org/details/tomdickandharry20992gut\",\"userDefinedField1\":null,\"userDefinedField2\":null,\"userDefinedField3\":null,\"userDefinedField4\":null,\"userDefinedField5\":null}],\"description\":null,\"edition\":null,\"isPeerReviewed\":false,\"contributorsList\":[{\"type\":\"author\",\"contributor\":\"Reed, Talbot Baines\"}]}");
+      } else if (req.path().equals("/rm/rmaccounts/test/titles/1111111")) {
+        req.response().setStatusCode(404).end(readMockFile(MOCK_RMAPI_INSTANCE_TITLE_404_FILE));
       }
     });
     server.listen(serverPort, host, ar -> {
@@ -374,6 +379,56 @@ public class RMAPIToCodexTest {
     }).whenComplete((response, throwable) -> {
       context.assertEquals(524, response.getTotalRecords());
       context.assertEquals(5, response.getInstances().size());
+
+      async.complete();
+    }).exceptionally(throwable -> {
+      context.fail(throwable);
+      async.complete();
+      return null;
+    });
+  }
+
+  @Test
+  public void testGetInstancesIdSearch(TestContext context) {
+    Async async = context.async();
+
+    RMAPIConfiguration.getConfiguration(okapiHeaders).thenCompose(config -> {
+      final CQLParserForRMAPI cql;
+      try {
+        cql = new CQLParserForRMAPI("id=1619585", 0, 5);
+      } catch (UnsupportedEncodingException | QueryValidationException e) {
+        throw new CompletionException(e);
+      }
+
+      return RMAPIToCodex.getInstances(cql, vertx.getOrCreateContext(), config);
+    }).whenComplete((response, throwable) -> {
+      context.assertEquals(1, response.getTotalRecords());
+      context.assertEquals(1, response.getInstances().size());
+
+      async.complete();
+    }).exceptionally(throwable -> {
+      context.fail(throwable);
+      async.complete();
+      return null;
+    });
+  }
+
+  @Test
+  public void testGetInstancesIdSearchFail(TestContext context) {
+    Async async = context.async();
+
+    RMAPIConfiguration.getConfiguration(okapiHeaders).thenCompose(config -> {
+      final CQLParserForRMAPI cql;
+      try {
+        cql = new CQLParserForRMAPI("id=1111111", 0, 5);
+      } catch (UnsupportedEncodingException | QueryValidationException e) {
+        throw new CompletionException(e);
+      }
+
+      return RMAPIToCodex.getInstances(cql, vertx.getOrCreateContext(), config);
+    }).whenComplete((response, throwable) -> {
+      context.assertEquals(0, response.getTotalRecords());
+      context.assertEquals(0, response.getInstances().size());
 
       async.complete();
     }).exceptionally(throwable -> {

--- a/src/test/java/org/folio/pact/ModConfigurationPactTest.java
+++ b/src/test/java/org/folio/pact/ModConfigurationPactTest.java
@@ -42,7 +42,6 @@ public class ModConfigurationPactTest {
   public final PactProviderRuleMk2 mockProvider = new PactProviderRuleMk2("mod-configuration", this);
 
   private Field mock = null;
-  private Object previousMock = null;
 
   /**
    * @throws java.lang.Exception
@@ -55,7 +54,6 @@ public class ModConfigurationPactTest {
     // test.
     mock = HttpClientFactory.class.getDeclaredField("mock");
     mock.setAccessible(true);
-    previousMock = mock.get(null);
     mock.set(null, Boolean.FALSE);
 
     okapiHeaders.put("x-okapi-tenant", "rmapiconfigurationtest");
@@ -65,9 +63,10 @@ public class ModConfigurationPactTest {
   @After
   public void tearDown(TestContext context) throws Exception {
     if (mock != null) {
-      // Reset mock to the previous value...
+      // Set mock to TRUE, even if it hadn't been set to TRUE before so
+      // subsequent tests will use the mock...
       mock.setAccessible(true);
-      mock.set(null, previousMock);
+      mock.set(null, Boolean.TRUE);
     }
   }
 

--- a/src/test/java/org/folio/rmapi/RMAPIServiceTest.java
+++ b/src/test/java/org/folio/rmapi/RMAPIServiceTest.java
@@ -1,8 +1,7 @@
 package org.folio.rmapi;
 
-import java.io.InputStream;
+import static org.folio.utils.Utils.readMockFile;
 
-import org.apache.commons.io.IOUtils;
 import org.folio.rest.RestVerticle;
 import org.folio.utils.Utils;
 import org.junit.After;
@@ -16,8 +15,6 @@ import io.vertx.core.DeploymentOptions;
 import io.vertx.core.Vertx;
 import io.vertx.core.http.HttpServer;
 import io.vertx.core.json.JsonObject;
-import io.vertx.core.logging.Logger;
-import io.vertx.core.logging.LoggerFactory;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
@@ -29,7 +26,6 @@ import io.vertx.ext.unit.junit.VertxUnitRunner;
 @RunWith(VertxUnitRunner.class)
 public class RMAPIServiceTest {
 
-  private final Logger logger = LoggerFactory.getLogger("okapi");
   private final String testCustId = "TESTCUSTID";
   private final String testAPIKey = "TESTAPIKEY";
   private final String testRMAPIHOST = "localhost";
@@ -273,19 +269,4 @@ public class RMAPIServiceTest {
       async.complete();
     });
   }
-
-  private String readMockFile(String path) {
-    try {
-      InputStream is = RMAPIServiceTest.class.getClassLoader().getResourceAsStream(path);
-      if (is != null) {
-        return IOUtils.toString(is, "UTF-8");
-      } else {
-        return "";
-      }
-    } catch (Throwable e) {
-      logger.error(String.format("Unable to read mock configuration in %s file", path));
-    }
-    return "";
-  }
-
 }

--- a/src/test/java/org/folio/utils/Utils.java
+++ b/src/test/java/org/folio/utils/Utils.java
@@ -4,14 +4,22 @@
 package org.folio.utils;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.ServerSocket;
 import java.util.Random;
+
+import org.apache.commons.io.IOUtils;
+
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
 
 /**
  * @author mreno
  *
  */
 public final class Utils {
+  private static final Logger logger = LoggerFactory.getLogger("okapi");
+
   private Utils() {
     super();
   }
@@ -25,10 +33,10 @@ public final class Utils {
   public static int getRandomPort() {
     int port = -1;
     do {
-      // Use a random ephemeral port if not defined via a system property
+      // Use a random ephemeral port
       port = new Random().nextInt(16_384) + 49_152;
       try {
-        ServerSocket socket = new ServerSocket(port);
+        final ServerSocket socket = new ServerSocket(port);
         socket.close();
       } catch (IOException e) {
         continue;
@@ -37,5 +45,21 @@ public final class Utils {
     } while (true);
 
     return port;
+  }
+
+  public static String readMockFile(final String path) {
+    try {
+      final InputStream is = Utils.class.getClassLoader().getResourceAsStream(path);
+
+      if (is != null) {
+        return IOUtils.toString(is, "UTF-8");
+      } else {
+        return "";
+      }
+    } catch (Throwable e) {
+      logger.error(String.format("Unable to read mock configuration in %s file", path));
+    }
+
+    return "";
   }
 }


### PR DESCRIPTION
## Purpose
Implement search by ID

## Approach
Added support to search by ID when the CQL parser indicates that the search field is "id". In this case, since there is no mechanism to search by KBID in the RM API and it is not possible or practical to retrieve all titles and check the KBID sequentially, we do not make the RM API call to search titles, rather we make the RM API call to retrieve a title by ID.

If the title is found, we convert to an instance and store the instance in an InstanceCollection of length 1. If the title is not found, we return an InstanceCollection of length 0.

Also fixed a problem with the PACT test affecting the FOLIO HttpClientFactory mocking setting depending on the order the tests are executed. We now assume mocking is enabled whenever the tests are run (the PACT test needs to disable mocking to execute properly, however when complete it will now always turn it back on, even if it was not on prior to the test, i.e. the PACT test was the first test executed).
