### PR TITLE
MODCXEKB-8: added Pact test for the RM API

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+## 0.0.4 2018-01-10
+ * MODCXEKB-8: Added consumer PACT support for dependent APIs (mod-confguration and RM API).
+
 ## 0.0.3 2018-01-05
  * MODCXEKB-54: Change totalRecords to resultInfo.totalRecords
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,5 @@
 ## 0.0.4 2018-01-10
- * MODCXEKB-8: Added consumer PACT support for dependent APIs (mod-confguration and RM API).
+ * MODCXEKB-8: Added consumer Pact support for dependent APIs (mod-confguration and RM API).
 
 ## 0.0.3 2018-01-05
  * MODCXEKB-54: Change totalRecords to resultInfo.totalRecords

--- a/pom.xml
+++ b/pom.xml
@@ -47,6 +47,7 @@
     <ramlfiles_path>${basedir}/ramls/raml-util/ramls/codex</ramlfiles_path>
     <ramlfiles_util_path>${basedir}/ramls/raml-util</ramlfiles_util_path>
     <dependency.locations.enabled>false</dependency.locations.enabled>
+    <pact.version>3.5.11</pact.version>
   </properties>
 
   <repositories>
@@ -127,13 +128,13 @@
     <dependency>
       <groupId>au.com.dius</groupId>
       <artifactId>pact-jvm-consumer-junit_2.12</artifactId>
-      <version>3.5.10</version>
+      <version>${pact.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>au.com.dius</groupId>
       <artifactId>pact-jvm-consumer-java8_2.12</artifactId>
-      <version>3.5.10</version>
+      <version>${pact.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.folio</groupId>
   <artifactId>mod-codex-ekb</artifactId>
-  <version>0.0.3-SNAPSHOT</version>
+  <version>0.0.4-SNAPSHOT</version>
 
   <name>EBSCO Knowledge Base Codex Module</name>
   <url>https://github.com/folio-org/mod-codex-ekb</url>

--- a/src/test/java/org/folio/pact/RMAPIPactTest.java
+++ b/src/test/java/org/folio/pact/RMAPIPactTest.java
@@ -54,7 +54,7 @@ public class RMAPIPactTest {
     final Map<String, String> headers = new HashMap<>();
     headers.put("x-api-key", "123456789");
 
-    // List Titles PACT
+    // List Titles Pact
     final DslPart listTitlesBody = newJsonBody(o -> {
       o.array("titles", a -> {
         a.object(prop -> {
@@ -111,7 +111,7 @@ public class RMAPIPactTest {
       .numberValue("totalResults", 1);
     }).build();
 
-    // Get Title by ID PACT
+    // Get Title by ID Pact
     final DslPart getTitleByIdBbody = newJsonBody(o -> {
       o.stringType("description", "edition", "titleName", "publisherName", "pubType")
         .booleanType("isPeerReviewed", "isTitleCustom")

--- a/src/test/java/org/folio/pact/RMAPIPactTest.java
+++ b/src/test/java/org/folio/pact/RMAPIPactTest.java
@@ -1,0 +1,220 @@
+package org.folio.pact;
+
+import static io.pactfoundation.consumer.dsl.LambdaDsl.newJsonBody;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.folio.rmapi.RMAPIService;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import au.com.dius.pact.consumer.Pact;
+import au.com.dius.pact.consumer.PactProviderRuleMk2;
+import au.com.dius.pact.consumer.PactVerification;
+import au.com.dius.pact.consumer.dsl.DslPart;
+import au.com.dius.pact.consumer.dsl.PactDslWithProvider;
+import au.com.dius.pact.model.RequestResponsePact;
+import io.vertx.core.Vertx;
+import io.vertx.ext.unit.Async;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+
+/**
+ * @author mreno
+ *
+ */
+@RunWith(VertxUnitRunner.class)
+public class RMAPIPactTest {
+  // This Rule *MUST* be public or there is an initialization error in JUnit.
+  @Rule
+  public final PactProviderRuleMk2 mockRMAPIProvider = new PactProviderRuleMk2("rm-api", this);
+
+  private Vertx vertx;
+
+  /**
+   * @throws java.lang.Exception
+   */
+  @Before
+  public void setUp(TestContext context) throws Exception {
+    vertx = Vertx.vertx();
+  }
+
+  @After
+  public void after(TestContext context) {
+    vertx.close(context.asyncAssertSuccess());
+  }
+
+  @Pact(provider="rm-api", consumer="mod-codex-ekb")
+  public RequestResponsePact createPact(PactDslWithProvider builder) throws IOException {
+    final Map<String, String> headers = new HashMap<>();
+    headers.put("x-api-key", "123456789");
+
+    // List Titles PACT
+    final DslPart listTitlesBody = newJsonBody(o -> {
+      o.array("titles", a -> {
+        a.object(prop -> {
+          prop.numberType("titleId")
+            .stringType("titleName")
+            .stringType("publisherName")
+            .array("identifierList", il -> {
+              il.object(i -> {
+                i.stringType("id", "source")
+                  .numberType("subType", "type");
+              });
+            })
+            .array("subjectsList", sl -> {
+              sl.object(s -> {
+                s.stringType("type", "subject");
+              });
+            })
+            .booleanType("isTitleCustom")
+            .stringType("pubType")
+            .array("customerResourcesList", crl -> {
+              crl.object(cr -> {
+                cr.numberType("titleId", "packageId", "vendorId", "locationId")
+                  .stringType("packageName", "packageType", "vendorName",
+                      "coverageStatement", "url", "userDefinedField1",
+                      "userDefinedField2", "userDefinedField3",
+                      "userDefinedField4", "userDefinedField5")
+                  .booleanType("isCustomPackage", "isSelected", "isTokenNeeded")
+                  .object("visibilityData", vd -> {
+                    vd.booleanType("isHidden")
+                      .stringType("reason");
+                  })
+                  .array("managedCoverageList", mcl -> {
+                    mcl.object(mc -> {
+                      mc.stringType("beginCoverage", "endCoverage");
+                    });
+                  })
+                  .array("customCoverageList", ccl -> {
+                    ccl.object(cc -> {
+                      cc.stringType("beginCoverage", "endCoverage");
+                    });
+                  })
+                  .object("managedEmbargoPeriod", mep -> {
+                    mep.stringType("embargoUnit")
+                      .numberType("embargoValue");
+                  })
+                  .object("customEmbargoPeriod", cep -> {
+                    cep.stringType("embargoUnit")
+                    .numberType("embargoValue");
+                  });
+              });
+            });
+        });
+      })
+      .numberValue("totalResults", 1);
+    }).build();
+
+    // Get Title by ID PACT
+    final DslPart getTitleByIdBbody = newJsonBody(o -> {
+      o.stringType("description", "edition", "titleName", "publisherName", "pubType")
+        .booleanType("isPeerReviewed", "isTitleCustom")
+        .numberValue("titleId", 1234567)
+        .array("contributorsList", cl -> {
+          cl.object(c -> {
+            c.stringType("type", "contributor");
+          });
+        })
+        .array("identifiersList", il -> {
+          il.object(i -> {
+            i.numberType("id", "subType", "type")
+              .stringType("source");
+          });
+        })
+        .array("subjectsList", sl -> {
+          sl.object(s -> {
+            s.stringType("subject", "type");
+          });
+        })
+        .array("customerResourcesList", crl -> {
+          crl.object(cr -> {
+            cr.numberType("titleId", "packageId", "vendorId", "locationId")
+              .stringType("packageName", "packageType", "vendorName",
+                  "coverageStatement", "url", "userDefinedField1",
+                  "userDefinedField2", "userDefinedField3",
+                  "userDefinedField4", "userDefinedField5")
+              .booleanType("isCustomPackage", "isSelected", "isTokenNeeded")
+              .object("visibilityData", vd -> {
+                vd.booleanType("isHidden")
+                  .stringType("reason");
+              })
+              .array("managedCoverageList", mcl -> {
+                mcl.object(mc -> {
+                  mc.stringType("beginCoverage", "endCoverage");
+                });
+              })
+              .array("customCoverageList", ccl -> {
+                ccl.object(cc -> {
+                  cc.stringType("beginCoverage", "endCoverage");
+                });
+              })
+              .object("managedEmbargoPeriod", mep -> {
+                mep.stringType("embargoUnit")
+                  .numberType("embargoValue");
+              })
+              .object("customEmbargoPeriod", cep -> {
+                cep.stringType("embargoUnit")
+                .numberType("embargoValue");
+              });
+          });
+        });
+    }).build();
+
+    return builder
+        .given("List Titles")
+        .uponReceiving("a request for titles with moby dick")
+          .path("/rm/rmaccounts/testcust/titles")
+          .query("search=moby dick&searchfield=titlename&orderby=titlename&count=10&offset=1")
+          .headers(headers)
+          .method("GET")
+        .willRespondWith()
+          .status(200)
+          .body(listTitlesBody)
+        .given("Get Title By ID")
+        .uponReceiving("A title request for ID 1234567")
+          .path("/rm/rmaccounts/testcust/titles/1234567")
+          .headers(headers)
+          .method("GET")
+        .willRespondWith()
+          .status(200)
+          .body(getTitleByIdBbody)
+        .toPact();
+  }
+
+  @Test
+  @PactVerification("rm-api")
+  public void pactTest(TestContext context) {
+    final Async listTitlesAsync = context.async();
+    final Async getTitleByIdAsync = context.async();
+
+    final RMAPIService rmapiService = new RMAPIService("testcust", "123456789", mockRMAPIProvider.getUrl(), vertx);
+
+    rmapiService.getTitleList("search=moby%20dick&searchfield=titlename&orderby=titlename&count=10&offset=1")
+      .whenComplete((titles, throwable) -> {
+        context.assertNotNull(titles, "titles is null");
+        context.assertEquals(1, titles.totalResults);
+        listTitlesAsync.complete();
+      }).exceptionally(throwable -> {
+        context.fail(throwable);
+        listTitlesAsync.complete();
+        return null;
+      });
+
+    rmapiService.getTitleById(1234567)
+      .whenComplete((title, throwable) -> {
+        context.assertNotNull(title, "title is null");
+        context.assertEquals(1234567, title.titleId);
+        getTitleByIdAsync.complete();
+      }).exceptionally(throwable -> {
+        context.fail(throwable);
+        getTitleByIdAsync.complete();
+        return null;
+      });
+  }
+}


### PR DESCRIPTION
## Purpose
Pact support in mod-codex-ekb

## Approach
Added an initial Pact test for the 2 RM API resources we use, list titles and get titles by ID. Of course, like the mod-configuration Pact, there is no provider verification at this point, so these consumer Pacts are just based on the latest known state of the provider's API. Pact adoption for all dependent APIs will be required to make these Pacts useful. Baby steps... :)

Also bumped the version of Pact we use in the POM.

#### TODOS and Open Questions
- [ ] Pact support for dependent providers.
- [ ] Publishing the mod-codex-ekb consumer Pacts to a Pact broker.
- [ ] Pact support in mod-codex-ekb as a provider; mod-codex-mux is a consumer of mod-codex-ekb and a consumer/provider Pact process should be put in place.

## Learning
https://github.com/DiUS/pact-jvm/tree/master/pact-jvm-consumer-junit
