### PR TITLE
add launch desc to MD template.  folio-1111

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -37,5 +37,12 @@
         "codex.item.get"
       ]
     }
-  ]
+  ],
+  "launchDescriptor": {
+    "dockerImage": "${artifactId}:${version}",
+    "dockerArgs": {
+      "HostConfig": { "PortBindings": { "8081/tcp":  [{ "HostPort": "%p" }] } } 
+    },
+    "dockerPull" : false
+  }
 }


### PR DESCRIPTION
## Purpose
Add a generic launch descriptor to the module descriptor template in order to enable module installation via Okapi install endpoint. 


