### PR TITLE
MODCXEKB-69: Add support for search by subject in codex-ekb

### DIFF
--- a/src/main/java/org/folio/cql2rmapi/CQLParserForRMAPI.java
+++ b/src/main/java/org/folio/cql2rmapi/CQLParserForRMAPI.java
@@ -40,6 +40,8 @@ public class CQLParserForRMAPI {
   private static final String CODEX_RESOURCE_TYPE = "codex.resourceType";
   private static final String IDENTIFIER = "identifier";
   private static final String CODEX_IDENTIFIER = "codex.identifier";
+  private static final String SUBJECT = "subject";
+  private static final String CODEX_SUBJECT = "codex.subject";
   private static final String PUBLISHER = "publisher";
   private static final String CODEX_PUBLISHER = "codex.publisher";
   private static final String ID = "id";
@@ -144,7 +146,7 @@ public class CQLParserForRMAPI {
         // CQL fields that are in the ext context set should be ignored if they
         // are not recognized by the module.
         break;
-      } else if(Stream.of(TITLE, CODEX_TITLE, IDENTIFIER, CODEX_IDENTIFIER, PUBLISHER, CODEX_PUBLISHER, ID, CODEX_ID).noneMatch(indexNode::equalsIgnoreCase)) {
+      } else if(Stream.of(TITLE, CODEX_TITLE, IDENTIFIER, CODEX_IDENTIFIER, PUBLISHER, CODEX_PUBLISHER, SUBJECT, CODEX_SUBJECT, ID, CODEX_ID).noneMatch(indexNode::equalsIgnoreCase)) {
         // If search field is not supported, log and return an error response
         builder.append("Search field or filter value ");
         builder.append(indexNode);
@@ -269,6 +271,8 @@ public class CQLParserForRMAPI {
         searchField = "isxn";
       } else if (searchField.equalsIgnoreCase(PUBLISHER) || searchField.equalsIgnoreCase(CODEX_PUBLISHER)) {
         searchField = PUBLISHER;
+      } else if (searchField.equalsIgnoreCase(SUBJECT) || searchField.equalsIgnoreCase(CODEX_SUBJECT)) {
+          searchField = SUBJECT;
       }
 
       if (sortType == null) {

--- a/src/test/java/org/folio/cql2rmapi/CQLParserForRMAPITest.java
+++ b/src/test/java/org/folio/cql2rmapi/CQLParserForRMAPITest.java
@@ -356,6 +356,27 @@ public class CQLParserForRMAPITest {
     }
   }
 
+  @Test
+  public void CQLParserReturnsExpectedQueriesIfCodexSubjectIsPassedTest() throws QueryValidationException, UnsupportedEncodingException {
+    final CQLParserForRMAPI parser = new CQLParserForRMAPI("codex.subject=history and resourceType = databases and ext.selected=false" , 900, 100);
+    final ArrayList<String> queries = (ArrayList<String>) parser.getRMAPIQueries();
+    assertEquals(1, queries.size());
+    assertEquals(0, parser.getInstanceIndex());
+    for (final String query: queries) {
+      assertEquals("search=history&searchfield=subject&resourcetype=database&selection=notselected&orderby=titlename&count=100&offset=10", query);
+    }
+  }
+
+  @Test
+  public void CQLParserReturnsExpectedQueriesIfSubjectIsPassedTest() throws QueryValidationException, UnsupportedEncodingException {
+    final CQLParserForRMAPI parser = new CQLParserForRMAPI("subject=history and resourceType = video and ext.selected=false" , 900, 100);
+    final ArrayList<String> queries = (ArrayList<String>) parser.getRMAPIQueries();
+    assertEquals(1, queries.size());
+    assertEquals(0, parser.getInstanceIndex());
+    for (final String query: queries) {
+      assertEquals("search=history&searchfield=subject&resourcetype=streamingvideo&selection=notselected&orderby=titlename&count=100&offset=10", query);
+    }
+  }
   @Test(expected = QueryValidationException.class)
   public void CQLParserThrowsExceptionIfInvalidSearchFieldWithPrefixIsPassedTest() throws QueryValidationException, UnsupportedEncodingException {
     new CQLParserForRMAPI("codex.resourceType=12345" , 900, 100);


### PR DESCRIPTION
## Purpose
Per https://issues.folio.org/browse/MODCXEKB-69, add support for being able to search by subject in mod-codex-ekb.

## Approach
- Add support for receiving "subject=xxx" from mux and passing back results
- Add unit tests accordingly

#### TODOS and Open Questions
- [ ] Figure out if we need to change any handling in mux to be able to return response from here to UI. Noticed that Inventory already supports this kind of search.
- [ ] Figure out if we need to do anything in the UI module to enable the search by subject for codex users
