### PR TITLE
MODCXEKB-59: Handle null query string in mod-codex-ekb

### DIFF
--- a/src/main/java/org/folio/cql2rmapi/CQLParserForRMAPI.java
+++ b/src/main/java/org/folio/cql2rmapi/CQLParserForRMAPI.java
@@ -68,7 +68,7 @@ public class CQLParserForRMAPI {
   }
 
   public CQLParserForRMAPI(String query, int offset, int limit) throws QueryValidationException, UnsupportedEncodingException {
-    if(limit != 0) {
+    if(limit != 0 && query != null) {
       final CQLNode node = initCQLParser(query);
       checkNodeInstance(node);
       //If it is an id search field, we do not need to build the query since we can directly invoke RM API to look for that id
@@ -82,7 +82,7 @@ public class CQLParserForRMAPI {
         }
       }
     } else {
-      throw new QueryValidationException(ERROR + "Limit suggests that no results need to be returned.");
+      throw new QueryValidationException(ERROR + "Limit/Query suggests that no results need to be returned.");
     }
   }
 

--- a/src/test/java/org/folio/cql2rmapi/CQLParserForRMAPITest.java
+++ b/src/test/java/org/folio/cql2rmapi/CQLParserForRMAPITest.java
@@ -33,6 +33,18 @@ public class CQLParserForRMAPITest {
     final String invalidQuery = "";
     new CQLParserForRMAPI(invalidQuery, 1, 10);
   }
+  
+  @Test(expected = QueryValidationException.class)
+  public void initCQLParserThrowsExceptionIfQueryIsInvalidTest() throws QueryValidationException, UnsupportedEncodingException {
+    final String invalidQuery = "offset=1&limit=10";
+    new CQLParserForRMAPI(invalidQuery, 1, 10);
+  }
+  
+  @Test(expected = QueryValidationException.class)
+  public void initCQLParserThrowsExceptionIfQueryIsNullTest() throws QueryValidationException, UnsupportedEncodingException {
+    final String invalidQuery = null;
+    new CQLParserForRMAPI(invalidQuery, 1, 10);
+  }
 
   @Test
   public void initCQLParserReturnsInstanceOfCQLNodeIfQueryValidTest() throws QueryValidationException, UnsupportedEncodingException {

--- a/src/test/java/org/folio/rest/impl/CodexInstanceResourceImplTest.java
+++ b/src/test/java/org/folio/rest/impl/CodexInstanceResourceImplTest.java
@@ -292,7 +292,7 @@ public class CodexInstanceResourceImplTest {
         .then()
           .log()
           .ifValidationFails()
-          .statusCode(500);
+          .statusCode(400);
 
     // Test done
     logger.info("Test done");


### PR DESCRIPTION
## Purpose
Per https://issues.folio.org/browse/MODCXEKB-59, mod-codex-ekb is returning a 500 - Internal Server Error for query with a null query string. Fix that issue in this PR to return a 400 instead.

## Approach
- When we conduct a search with no query string parameter, mod-code-mux sends a query to mod-codex-ekb of the type `GET /codex-instances offset=0&limit=10`
- Notice how the `query=` param is missing in the request above
- mod-codex-ekb is not checking for that and instead invoking CQLParser which throws a NullPointerException; which in turn converts into a 500 response from mod-codex-ekb
- Fix mod-codex-ekb code to throw a `QueryValidationException` instead which is returned as a 400 - Bad Request instead from mod-codex-ekb to mod-codex-mux
- Add a couple of unit tests for the same scenario and adjust RestAssured test accordingly.
