### PR TITLE
MODCXEKB-58: Not authorized error should return 401 instead of 500 error

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
     <ramlfiles_path>${basedir}/ramls/raml-util/ramls/codex</ramlfiles_path>
-    <ramlfiles_util_path>${basedir}/ramls/raml-util</ramlfiles_util_path>
+    <rmb.version>21.0.4</rmb.version>
     <dependency.locations.enabled>false</dependency.locations.enabled>
     <pact.version>3.5.11</pact.version>
   </properties>
@@ -106,7 +106,7 @@
     <dependency>
       <groupId>org.folio</groupId>
       <artifactId>domain-models-runtime</artifactId>
-      <version>15.0.2</version>
+      <version>${rmb.version}</version>
     </dependency>
     <!-- According to https://github.com/rest-assured/rest-assured/wiki/GettingStarted, rest assured should be placed before junit to ensure correct version of Hamcrest is used.-->
     <dependency>
@@ -140,6 +140,13 @@
   </dependencies>
 
   <build>
+  	<resources>
+      <resource>
+        <directory>src/main/resources</directory>
+        <filtering>true</filtering>
+      </resource>
+    </resources>
+
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
@@ -150,6 +157,26 @@
           <target>1.8</target>
           <encoding>UTF-8</encoding>
         </configuration>
+      </plugin>
+	  
+	  <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>build-helper-maven-plugin</artifactId>
+        <version>3.0.0</version>
+        <executions>
+          <execution>
+            <id>add_generated_sources_folder</id>
+            <goals>
+              <goal>add-source</goal>
+            </goals>
+            <phase>initialize</phase>
+            <configuration>
+              <sources>
+                <source>${project.build.directory}/generated-sources/raml-jaxrs</source>
+              </sources>
+            </configuration>
+          </execution>
+        </executions>
       </plugin>
 
       <plugin>
@@ -196,6 +223,7 @@
           </execution>
         </executions>
       </plugin>
+      
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>aspectj-maven-plugin</artifactId>
@@ -254,22 +282,6 @@
               <resources>
                 <resource>
                   <directory>${ramlfiles_path}</directory>
-                  <filtering>true</filtering>
-                </resource>
-              </resources>
-            </configuration>
-          </execution>
-          <execution>
-            <id>copy-resources-2</id>
-            <phase>process-resources</phase>
-            <goals>
-              <goal>copy-resources</goal>
-            </goals>
-            <configuration>
-              <outputDirectory>${basedir}/target/classes/apidocs/raml-util</outputDirectory>
-              <resources>
-                <resource>
-                  <directory>${ramlfiles_util_path}</directory>
                   <filtering>true</filtering>
                 </resource>
               </resources>

--- a/src/main/java/org/folio/config/RMAPIConfiguration.java
+++ b/src/main/java/org/folio/config/RMAPIConfiguration.java
@@ -113,6 +113,7 @@ public final class RMAPIConfiguration {
               return mapResults(configs);
             }
             else if (response.getCode() == 401) {
+                LOG.error("Authorization failure getting configuration:" + CONFIGURATIONS_ENTRIES_ENDPOINT_PATH);
             	throw new NotAuthorizedException("Authorization failure getting configuration");  
             } else {
                 LOG.error("Cannot get configuration data: " + response.getError().toString(), response.getException());

--- a/src/main/java/org/folio/config/RMAPIConfiguration.java
+++ b/src/main/java/org/folio/config/RMAPIConfiguration.java
@@ -112,11 +112,10 @@ public final class RMAPIConfiguration {
 
               return mapResults(configs);
             }
-            else {
-            	LOG.error("Cannot get configuration data: " + response.getError().toString(), response.getException());
-            	if (response.getCode() == 401) {
-            		throw new NotAuthorizedException(response.getError().toString());
-            	}            	 
+            else if (response.getCode() == 401) {
+            	throw new NotAuthorizedException("Authorization failure getting configuration");  
+            } else {
+                LOG.error("Cannot get configuration data: " + response.getError().toString(), response.getException());
                  throw new IllegalStateException(response.getError().toString());
             }
           } finally {

--- a/src/main/java/org/folio/config/RMAPIConfiguration.java
+++ b/src/main/java/org/folio/config/RMAPIConfiguration.java
@@ -4,6 +4,8 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
+import javax.ws.rs.NotAuthorizedException;
+
 import org.folio.rest.RestVerticle;
 import org.folio.rest.tools.client.HttpClientFactory;
 import org.folio.rest.tools.client.Response;
@@ -109,9 +111,13 @@ public final class RMAPIConfiguration {
               final JsonArray configs = responseBody.getJsonArray("configs");
 
               return mapResults(configs);
-            } else {
-              LOG.error("Cannot get configuration data: " + response.getError().toString(), response.getException());
-              throw new IllegalStateException(response.getError().toString());
+            }
+            else {
+            	LOG.error("Cannot get configuration data: " + response.getError().toString(), response.getException());
+            	if (response.getCode() == 401) {
+            		throw new NotAuthorizedException(response.getError().toString());
+            	}            	 
+                 throw new IllegalStateException(response.getError().toString());
             }
           } finally {
             httpClient.closeClient();
@@ -124,7 +130,6 @@ public final class RMAPIConfiguration {
 
     return future;
   }
-
   /**
    * Simple mapper for the results of mod-configuration to RMAPIConfiguration.
    *

--- a/src/main/java/org/folio/rest/impl/CodexInstancesImpl.java
+++ b/src/main/java/org/folio/rest/impl/CodexInstancesImpl.java
@@ -4,6 +4,7 @@ import java.io.UnsupportedEncodingException;
 import java.util.Map;
 import java.util.concurrent.CompletionException;
 
+import javax.ws.rs.NotAuthorizedException;
 import javax.ws.rs.core.Response;
 
 import org.folio.rest.annotations.Validate;

--- a/src/main/java/org/folio/rest/impl/CodexInstancesImpl.java
+++ b/src/main/java/org/folio/rest/impl/CodexInstancesImpl.java
@@ -55,6 +55,8 @@ public final class CodexInstancesImpl implements CodexInstances {
         log.error("getCodexInstances failed!", throwable);
         if (throwable.getCause() instanceof QueryValidationException) {
           asyncResultHandler.handle(Future.succeededFuture(CodexInstances.GetCodexInstancesResponse.respond400WithTextPlain(throwable.getCause().getMessage())));
+        } else if (throwable.getCause() instanceof NotAuthorizedException) {
+          asyncResultHandler.handle(Future.succeededFuture(CodexInstances.GetCodexInstancesResponse.respond401WithTextPlain(throwable.getCause().getMessage())));
         } else {
           asyncResultHandler.handle(Future.succeededFuture(CodexInstances.GetCodexInstancesResponse.respond500WithTextPlain(throwable.getCause().getMessage())));
         }
@@ -81,8 +83,10 @@ public final class CodexInstancesImpl implements CodexInstances {
         if (throwable.getCause() instanceof RMAPIResourceNotFoundException) {
           asyncResultHandler.handle(
               Future.succeededFuture(CodexInstances.GetCodexInstancesByIdResponse.respond404WithTextPlain(id)));
+        } else if (throwable.getCause() instanceof NotAuthorizedException) {
+        	asyncResultHandler.handle(Future.succeededFuture(CodexInstances.GetCodexInstancesResponse.respond401WithTextPlain(throwable.getCause().getMessage())));
         } else {
-        asyncResultHandler.handle(Future.succeededFuture(CodexInstances.GetCodexInstancesByIdResponse.respond500WithTextPlain(throwable.getCause().getMessage())));
+        	asyncResultHandler.handle(Future.succeededFuture(CodexInstances.GetCodexInstancesByIdResponse.respond500WithTextPlain(throwable.getCause().getMessage())));
         }
         return null;
       });

--- a/src/test/java/org/folio/config/RMAPIConfigurationTest.java
+++ b/src/test/java/org/folio/config/RMAPIConfigurationTest.java
@@ -273,45 +273,44 @@ public class RMAPIConfigurationTest {
       return null;
     });
   }
+  
+  @Test
   public void return404Test(TestContext context) {
-	    Async async = context.async();
-
-	    try {
-	      // HACK ALERT! See above for the reason this is here.
-	      httpClientMock.setMockJsonContent(MOCK_CONTENT_FAIL_404_FILE);
-	    } catch (IOException e) {
-	      context.fail("Cannot read mock file: " +
-	          MOCK_CONTENT_FAIL_404_FILE + " - reason: " + e.getMessage());
-	    }
-
-	    CompletableFuture<RMAPIConfiguration> config = RMAPIConfiguration.getConfiguration(okapiHeaders);
-	    config.whenComplete((result, exception) -> {
-	      context.assertNull(result);
-
+	  Async async = context.async();
+	  
+	  try {
+		  // HACK ALERT! See above for the reason this is here.
+		  httpClientMock.setMockJsonContent(MOCK_CONTENT_FAIL_404_FILE);
+	  } catch (IOException e) {
+		  context.fail("Cannot read mock file: " + MOCK_CONTENT_FAIL_404_FILE + " - reason: " + e.getMessage());
+	  }
+	
+	  CompletableFuture<RMAPIConfiguration> config = RMAPIConfiguration.getConfiguration(okapiHeaders);
+	  config.whenComplete((result, exception) -> {
+		  context.assertNull(result);
 	      async.complete();
-	    });
-}
+	   });
+  }
   @Test
   public void return401Test(TestContext context) {
-	    Async async = context.async();
-
-	    try {
-	      // HACK ALERT! See above for the reason this is here.
-	      httpClientMock.setMockJsonContent(MOCK_CONTENT_FAIL_401_FILE);
-	    } catch (IOException e) {
-	      context.fail("Cannot read mock file: " +
-	    		  MOCK_CONTENT_FAIL_401_FILE + " - reason: " + e.getMessage());
-	    }
-
-	    CompletableFuture<RMAPIConfiguration> config = RMAPIConfiguration.getConfiguration(okapiHeaders);
-	    config.whenComplete((result, exception) -> {
-	      context.assertNull(result);
-	      context.assertTrue(exception.getCause() instanceof NotAuthorizedException);
-
-	      async.complete();
-	    });
-	 
-}
+	Async async = context.async();
+	
+	try {
+	  // HACK ALERT! See above for the reason this is here.
+	  httpClientMock.setMockJsonContent(MOCK_CONTENT_FAIL_401_FILE);
+	} catch (IOException e) {
+	  context.fail("Cannot read mock file: " +
+	  MOCK_CONTENT_FAIL_401_FILE + " - reason: " + e.getMessage());
+	}
+	
+	CompletableFuture<RMAPIConfiguration> config = RMAPIConfiguration.getConfiguration(okapiHeaders);
+	config.whenComplete((result, exception) -> {
+	  context.assertNull(result);
+	  context.assertTrue(exception.getCause() instanceof NotAuthorizedException);
+	
+	  async.complete();
+	});
+  }
   @Test
   public void cannotGetConfigDataTest(TestContext context) {
     Async async = context.async();

--- a/src/test/java/org/folio/config/RMAPIConfigurationTest.java
+++ b/src/test/java/org/folio/config/RMAPIConfigurationTest.java
@@ -5,6 +5,8 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
+import javax.ws.rs.NotAuthorizedException;
+
 import org.folio.rest.RestVerticle;
 import org.folio.rest.tools.client.test.HttpClientMock2;
 import org.folio.utils.Utils;
@@ -53,6 +55,7 @@ public class RMAPIConfigurationTest {
   private static final String MOCK_CONTENT_SUCCESS_MULTIPLE_FILE = "RMAPIConfiguration/mock_content_success_multiple.json";
   private static final String MOCK_CONTENT_SUCCESS_TO_STRING_FILE = "RMAPIConfiguration/mock_content_success_to_string.json";
   private static final String MOCK_CONTENT_FAIL_404_FILE = "RMAPIConfiguration/mock_content_fail_404.json";
+  private static final String MOCK_CONTENT_FAIL_401_FILE = "RMAPIConfiguration/mock_content_fail_401.json";
   private static final String MOCK_CONTENT_FAIL_INTERNAL_ERROR_FILE = "RMAPIConfiguration/mock_content_fail_internal_error.json";
 
   private final Logger logger = LoggerFactory.getLogger("okapi");
@@ -270,27 +273,45 @@ public class RMAPIConfigurationTest {
       return null;
     });
   }
-
-  @Test
   public void return404Test(TestContext context) {
-    Async async = context.async();
+	    Async async = context.async();
 
-    try {
-      // HACK ALERT! See above for the reason this is here.
-      httpClientMock.setMockJsonContent(MOCK_CONTENT_FAIL_404_FILE);
-    } catch (IOException e) {
-      context.fail("Cannot read mock file: " +
-          MOCK_CONTENT_FAIL_404_FILE + " - reason: " + e.getMessage());
-    }
+	    try {
+	      // HACK ALERT! See above for the reason this is here.
+	      httpClientMock.setMockJsonContent(MOCK_CONTENT_FAIL_404_FILE);
+	    } catch (IOException e) {
+	      context.fail("Cannot read mock file: " +
+	          MOCK_CONTENT_FAIL_404_FILE + " - reason: " + e.getMessage());
+	    }
 
-    CompletableFuture<RMAPIConfiguration> config = RMAPIConfiguration.getConfiguration(okapiHeaders);
-    config.whenComplete((result, exception) -> {
-      context.assertNull(result);
+	    CompletableFuture<RMAPIConfiguration> config = RMAPIConfiguration.getConfiguration(okapiHeaders);
+	    config.whenComplete((result, exception) -> {
+	      context.assertNull(result);
 
-      async.complete();
-    });
-  }
+	      async.complete();
+	    });
+}
+  @Test
+  public void return401Test(TestContext context) {
+	    Async async = context.async();
 
+	    try {
+	      // HACK ALERT! See above for the reason this is here.
+	      httpClientMock.setMockJsonContent(MOCK_CONTENT_FAIL_401_FILE);
+	    } catch (IOException e) {
+	      context.fail("Cannot read mock file: " +
+	    		  MOCK_CONTENT_FAIL_401_FILE + " - reason: " + e.getMessage());
+	    }
+
+	    CompletableFuture<RMAPIConfiguration> config = RMAPIConfiguration.getConfiguration(okapiHeaders);
+	    config.whenComplete((result, exception) -> {
+	      context.assertNull(result);
+	      context.assertTrue(exception.getCause() instanceof NotAuthorizedException);
+
+	      async.complete();
+	    });
+	 
+}
   @Test
   public void cannotGetConfigDataTest(TestContext context) {
     Async async = context.async();

--- a/src/test/java/org/folio/config/RMAPIConfigurationTest.java
+++ b/src/test/java/org/folio/config/RMAPIConfigurationTest.java
@@ -276,20 +276,19 @@ public class RMAPIConfigurationTest {
   
   @Test
   public void return404Test(TestContext context) {
-	  Async async = context.async();
-	  
-	  try {
-		  // HACK ALERT! See above for the reason this is here.
-		  httpClientMock.setMockJsonContent(MOCK_CONTENT_FAIL_404_FILE);
-	  } catch (IOException e) {
-		  context.fail("Cannot read mock file: " + MOCK_CONTENT_FAIL_404_FILE + " - reason: " + e.getMessage());
-	  }
+	Async async = context.async();
 	
-	  CompletableFuture<RMAPIConfiguration> config = RMAPIConfiguration.getConfiguration(okapiHeaders);
-	  config.whenComplete((result, exception) -> {
-		  context.assertNull(result);
-	      async.complete();
-	   });
+    try {
+	  // HACK ALERT! See above for the reason this is here.
+	  httpClientMock.setMockJsonContent(MOCK_CONTENT_FAIL_404_FILE);
+    } catch (IOException e) {
+	  context.fail("Cannot read mock file: " + MOCK_CONTENT_FAIL_404_FILE + " - reason: " + e.getMessage());
+    }
+    CompletableFuture<RMAPIConfiguration> config = RMAPIConfiguration.getConfiguration(okapiHeaders);
+    config.whenComplete((result, exception) -> {
+	  context.assertNull(result);
+      async.complete();
+   });
   }
   @Test
   public void return401Test(TestContext context) {

--- a/src/test/java/org/folio/rest/impl/CodexInstanceResourceImplTest.java
+++ b/src/test/java/org/folio/rest/impl/CodexInstanceResourceImplTest.java
@@ -36,6 +36,7 @@ public class CodexInstanceResourceImplTest {
   private static final String MOCK_RMAPI_INSTANCE_TITLE_200_RESPONSE_WHEN_FOUND = "RMAPIService/SuccessGetTitleById.json";
   private static final String MOCK_RMAPI_INSTANCE_TITLE_404_RESPONSE_WHEN_NOT_FOUND = "RMAPIConfiguration/mock_content_fail_404.json";
   private static final String MOCK_CODEX_INSTANCE_TITLE_COLLECTION_200_RESPONSE_WHEN_FOUND = "RMAPIService/SuccessGetTitleList.json";
+  private static final String MOCK_RMAPI_CONFIG_401_RESPONSE_WHEN_NOT_AUTH = "RMAPIConfiguration/mock_content_fail_401.json";
 
   private static final String SEARCH_TITLE_COLLECTION_WHEN_SEARCH_FIELD_NOT_GIVEN_SUCCESS_QUERY = "Bridget Jones";
   private static final String SEARCH_TITLE_COLLECTION_FAILS_UNSUPPORTED_QUERY = "title = Bridget Jones or publisher = xyz";
@@ -182,6 +183,34 @@ public class CodexInstanceResourceImplTest {
         .log()
         .ifValidationFails()
         .statusCode(404);
+
+    // Test done
+    logger.info("Test done");
+    asyncLocal.complete();
+  }
+  
+  @Test
+  public void getCodexInstancesByIdTitleNotAuth(TestContext context) {
+    final Async asyncLocal = context.async();
+    logger.info("Testing for response when not authorized");
+    
+    try {
+        // Mocking the RM API Configuration response
+        httpClientMock.setMockJsonContent(MOCK_RMAPI_CONFIG_401_RESPONSE_WHEN_NOT_AUTH);
+      } catch (final IOException e) {
+        context.fail("Cannot read mock file: " + MOCK_RMAPI_CONFIG_401_RESPONSE_WHEN_NOT_AUTH + " - reason: " + e.getMessage());
+      }
+
+    RestAssured
+    .given()
+      .header(tenantHeader)
+      .header(urlHeader)
+      .header(contentTypeHeader)
+    .get("/codex-instances/99999")
+      .then()
+        .log()
+        .ifValidationFails()
+        .statusCode(401);
 
     // Test done
     logger.info("Test done");

--- a/src/test/java/org/folio/rest/impl/CodexInstanceResourceImplTest.java
+++ b/src/test/java/org/folio/rest/impl/CodexInstanceResourceImplTest.java
@@ -195,7 +195,7 @@ public class CodexInstanceResourceImplTest {
     logger.info("Testing for response when not authorized");
     
     try {
-        // Mocking the RM API Configuration response
+        // Override default Mocking of RM API Configuration response
         httpClientMock.setMockJsonContent(MOCK_RMAPI_CONFIG_401_RESPONSE_WHEN_NOT_AUTH);
       } catch (final IOException e) {
         context.fail("Cannot read mock file: " + MOCK_RMAPI_CONFIG_401_RESPONSE_WHEN_NOT_AUTH + " - reason: " + e.getMessage());

--- a/src/test/resources/RMAPIConfiguration/mock_content_fail_401.json
+++ b/src/test/resources/RMAPIConfiguration/mock_content_fail_401.json
@@ -1,21 +1,10 @@
 {
   "mocks": [
     {
-      "description": "Unconfigured RM API Configuration",
+      "description": "UnAuthorized to access RM API Configuration",
       "url": "/configurations/entries?query=%28module%3D%3DEKB%20AND%20configName%3D%3Dapi_access%29",
       "method": "get",
-      "status": 401,
-      "receivedData": {
-        "configs" : [ {
-        } ],
-        "totalRecords" : 0,
-        "resultInfo" : {
-          "totalRecords" : 0,
-          "facets" : [ ]
-        }
-      },
-      "receivedPath": "",
-      "sendData": {}
+      "status": 401
     }
   ]
 }

--- a/src/test/resources/RMAPIConfiguration/mock_content_fail_401.json
+++ b/src/test/resources/RMAPIConfiguration/mock_content_fail_401.json
@@ -1,0 +1,21 @@
+{
+  "mocks": [
+    {
+      "description": "Unconfigured RM API Configuration",
+      "url": "/configurations/entries?query=%28module%3D%3DEKB%20AND%20configName%3D%3Dapi_access%29",
+      "method": "get",
+      "status": 401,
+      "receivedData": {
+        "configs" : [ {
+        } ],
+        "totalRecords" : 0,
+        "resultInfo" : {
+          "totalRecords" : 0,
+          "facets" : [ ]
+        }
+      },
+      "receivedPath": "",
+      "sendData": {}
+    }
+  ]
+}


### PR DESCRIPTION
## Purpose
Per https://issues.folio.org/browse/MODCXEKB-58 mod-codex-ekb was throwing a 500 error instead of a 401 error when a user was not authorized to access.

This was found when API tests were being developed for mod-codex-ekb

Note -- found comment in api tests indicating a resolution
https://github.com/folio-org/folio-api-tests/blob/81772a6d20f4474781156ade7db99f60e051ae9f/mod-codex-ekb/mod-codex-ekb.postman_collection.json#L2321  

## Approach
- Tested current mod-codex-ekb module access against a vagrant box to confirm error was corrected
- For example -- made a request such as the following with an invalid `x-okapi-token`  header `GET http://localhost:9130/codex-instances?limit=30&offset=30&query=%28%28title%3D%22%22great%20gatsby%22%2A%22%29%20and%20source%3D%22kb%22%29%20sortby%20title`
- Observed 401 status code returned with invalid token
- Tested local copy of mod-codex-ekb run against vagrant `java -jar target\mod-codex-ekb-fat.jar -Dokapi.url=http://localhost:9130`
- made similar request `GET http://0.0.0.0:8081/codex-instances?limit=30&offset=30&query=%28%28title%3D%22%22great%20gatsby%22%2A%22%29%20and%20source%3D%22kb%22%29%20sortby%20title` and observed 500 status error
- Updated RMAPIConfiguration to detect 401 response from GET for Configuration Data
- Updated CodexInstancesResourceImpl class to return 401 Status code 
- Added unit tests for both with associated Mock result for 401 response.
