### PR TITLE
MODCXEKB-67: Update mod-codex-ekb to use RAML 1.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,6 +46,7 @@
     <maven.compiler.target>1.8</maven.compiler.target>
     <ramlfiles_path>${basedir}/ramls/raml-util/ramls/codex</ramlfiles_path>
     <ramlfiles_util_path>${basedir}/ramls/raml-util</ramlfiles_util_path>
+    <rmb.version>21.0.4</rmb.version>
     <dependency.locations.enabled>false</dependency.locations.enabled>
     <pact.version>3.5.11</pact.version>
   </properties>
@@ -106,7 +107,7 @@
     <dependency>
       <groupId>org.folio</groupId>
       <artifactId>domain-models-runtime</artifactId>
-      <version>15.0.2</version>
+      <version>${rmb.version}</version>
     </dependency>
     <!-- According to https://github.com/rest-assured/rest-assured/wiki/GettingStarted, rest assured should be placed before junit to ensure correct version of Hamcrest is used.-->
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,6 @@
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
     <ramlfiles_path>${basedir}/ramls/raml-util/ramls/codex</ramlfiles_path>
-    <ramlfiles_util_path>${basedir}/ramls/raml-util</ramlfiles_util_path>
     <rmb.version>21.0.4</rmb.version>
     <dependency.locations.enabled>false</dependency.locations.enabled>
     <pact.version>3.5.11</pact.version>
@@ -283,22 +282,6 @@
               <resources>
                 <resource>
                   <directory>${ramlfiles_path}</directory>
-                  <filtering>true</filtering>
-                </resource>
-              </resources>
-            </configuration>
-          </execution>
-          <execution>
-            <id>copy-resources-2</id>
-            <phase>process-resources</phase>
-            <goals>
-              <goal>copy-resources</goal>
-            </goals>
-            <configuration>
-              <outputDirectory>${basedir}/target/classes/apidocs/raml-util</outputDirectory>
-              <resources>
-                <resource>
-                  <directory>${ramlfiles_util_path}</directory>
                   <filtering>true</filtering>
                 </resource>
               </resources>

--- a/pom.xml
+++ b/pom.xml
@@ -141,6 +141,13 @@
   </dependencies>
 
   <build>
+  	<resources>
+      <resource>
+        <directory>src/main/resources</directory>
+        <filtering>true</filtering>
+      </resource>
+    </resources>
+
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
@@ -151,6 +158,26 @@
           <target>1.8</target>
           <encoding>UTF-8</encoding>
         </configuration>
+      </plugin>
+	  
+	  <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>build-helper-maven-plugin</artifactId>
+        <version>3.0.0</version>
+        <executions>
+          <execution>
+            <id>add_generated_sources_folder</id>
+            <goals>
+              <goal>add-source</goal>
+            </goals>
+            <phase>initialize</phase>
+            <configuration>
+              <sources>
+                <source>${project.build.directory}/generated-sources/raml-jaxrs</source>
+              </sources>
+            </configuration>
+          </execution>
+        </executions>
       </plugin>
 
       <plugin>
@@ -197,6 +224,7 @@
           </execution>
         </executions>
       </plugin>
+      
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>aspectj-maven-plugin</artifactId>


### PR DESCRIPTION
## Purpose
Per https://issues.folio.org/browse/MODCXEKB-67, we are supposed to update mod-codex-ekb to use RAML 1.0; this PR is intended to address that issue.

## Approach
- Since changes to the RAML itself were already taken care of on raml1.0 branch, followed the steps below to let this module point to the latest in that branch:
cd ramls/raml-util
git fetch
git checkout raml1.0
cd ../..
git add ramls/raml-util
git commit -m "Commit message"
git push origin branch_name
- I was having trouble getting those changes reflected in my git clone on local
- Having tried many things, I had delete and git clone mod-codex-ekb all over again, switch to my branch and git submodule update
- That showed the compilation errors which following https://github.com/folio-org/raml-module-builder/blob/master/doc/upgrading.md, were pretty easy to update

## Learning
- https://github.com/folio-org/raml-module-builder/blob/master/doc/upgrading.md
- https://github.com/folio-org/raml-module-builder