### PR TITLE
MODCXEKB-68: Support Subjects in response from Codex

### DIFF
--- a/src/main/java/org/folio/codex/RMAPIToCodex.java
+++ b/src/main/java/org/folio/codex/RMAPIToCodex.java
@@ -15,6 +15,7 @@ import org.folio.rest.jaxrs.model.Identifier;
 import org.folio.rest.jaxrs.model.Instance;
 import org.folio.rest.jaxrs.model.InstanceCollection;
 import org.folio.rest.jaxrs.model.ResultInfo;
+import org.folio.rest.jaxrs.model.Subject;
 import org.folio.rmapi.RMAPIResourceNotFoundException;
 import org.folio.rmapi.RMAPIService;
 import org.folio.rmapi.model.Title;
@@ -122,7 +123,13 @@ public final class RMAPIToCodex {
           .map(RMAPIToCodex::convertRMContributorToCodex)
           .collect(Collectors.toSet()));
     }
-
+    
+    if ((svcTitle.subjectsList != null) && (!svcTitle.subjectsList.isEmpty())) {
+        codexInstance.setSubject(svcTitle.subjectsList.stream()
+            .map(RMAPIToCodex::convertRMSubjectToCodex)
+            .collect(Collectors.toSet()));
+      }
+    
     return codexInstance;
   }
 
@@ -152,6 +159,12 @@ public final class RMAPIToCodex {
     return new Contributor()
         .withName(rmContributor.titleContributor)
         .withType(rmContributor.type);
+  }
+  
+  private static Subject convertRMSubjectToCodex(org.folio.rmapi.model.Subject rmSubject) {
+    return new Subject()
+        .withName(rmSubject.titleSubject)
+        .withType(rmSubject.type);
   }
 
   private static CompletableFuture<InstanceCollection> convertRMTitleListToCodex(List<CompletableFuture<Titles>> titleCfs, int index, int limit) {

--- a/src/test/java/org/folio/codex/RMAPIToCodexTest.java
+++ b/src/test/java/org/folio/codex/RMAPIToCodexTest.java
@@ -16,6 +16,7 @@ import org.folio.cql2rmapi.CQLParserForRMAPI;
 import org.folio.cql2rmapi.QueryValidationException;
 import org.folio.rest.RestVerticle;
 import org.folio.rest.jaxrs.model.Contributor;
+import org.folio.rest.jaxrs.model.Subject;
 import org.folio.rest.jaxrs.model.Identifier;
 import org.folio.rest.jaxrs.model.Instance;
 import org.folio.rest.tools.client.test.HttpClientMock2;
@@ -154,6 +155,7 @@ public class RMAPIToCodexTest {
       context.assertEquals(1, response.getContributor().size());
       context.assertEquals("author", response.getContributor().iterator().next().getType());
       context.assertEquals("Reed, Talbot Baines", response.getContributor().iterator().next().getName());
+      context.assertTrue(response.getSubject().isEmpty());
       context.assertEquals("Project Gutenberg Literary Archive Foundation", response.getPublisher());
       context.assertEquals(Instance.Type.EBOOKS, response.getType());
       context.assertEquals("Electronic Resource", response.getFormat());
@@ -200,6 +202,16 @@ public class RMAPIToCodexTest {
       context.assertTrue(foundAuthor2);
       context.assertTrue(foundEditor1);
       context.assertTrue(foundEditor2);
+      context.assertEquals(1, response.getSubject().size());
+      boolean foundSubject = false;
+      for (Subject s : response.getSubject()) {
+          if ("BISAC".equals(s.getType()) && "LITERARY CRITICISM / Science Fiction & Fantasy".equals(s.getName())) {
+        	  foundSubject = true;
+          } else {
+            context.fail("Unknown subject: " + s.getName() + ' ' + s.getType());
+          }
+        }
+      context.assertTrue(foundSubject);
       context.assertEquals("Palgrave Macmillan Ltd.", response.getPublisher());
       context.assertEquals(Instance.Type.EBOOKS, response.getType());
       context.assertEquals("Electronic Resource", response.getFormat());
@@ -284,6 +296,16 @@ public class RMAPIToCodexTest {
       context.assertTrue(foundIdentifier1);
       context.assertTrue(foundIdentifier2);
       context.assertTrue(foundIdentifier3);
+      context.assertEquals(1, response.getSubject().size());
+      boolean foundSubject = false;
+      for (Subject s : response.getSubject()) {
+          if ("BISAC".equals(s.getType()) && "LITERARY CRITICISM / Science Fiction & Fantasy".equals(s.getName())) {
+        	  foundSubject = true;
+          } else {
+            context.fail("Unknown subject: " + s.getName() + ' ' + s.getType());
+          }
+        }
+      context.assertTrue(foundSubject);
       context.assertEquals("kb", response.getSource());
       context.assertTrue(response.getLanguage().isEmpty());
 
@@ -307,6 +329,7 @@ public class RMAPIToCodexTest {
       context.assertEquals(1, response.getContributor().size());
       context.assertEquals("author", response.getContributor().iterator().next().getType());
       context.assertEquals("Reed, Talbot Baines", response.getContributor().iterator().next().getName());
+      context.assertTrue(response.getSubject().isEmpty());
       context.assertEquals("Project Gutenberg Literary Archive Foundation", response.getPublisher());
       context.assertEquals(Instance.Type.EBOOKS, response.getType());
       context.assertEquals("Electronic Resource", response.getFormat());
@@ -363,6 +386,32 @@ public class RMAPIToCodexTest {
       return null;
     });
   }
+  
+  @Test
+  public void testGetInstanceEmptySubjectList(TestContext context) {
+    Async async = context.async();
+
+    RMAPIConfiguration.getConfiguration(okapiHeaders).thenCompose(config -> {
+      return RMAPIToCodex.getInstance("1619586", vertx.getOrCreateContext(), config);
+    }).whenComplete((response, throwable) -> {
+      context.assertEquals("1619586", response.getId());
+      context.assertEquals("Tom, Dick and Harry", response.getTitle());
+      context.assertTrue(response.getSubject().isEmpty());
+      context.assertEquals("Project Gutenberg Literary Archive Foundation", response.getPublisher());
+      context.assertEquals(Instance.Type.EBOOKS, response.getType());
+      context.assertEquals("Electronic Resource", response.getFormat());
+      context.assertTrue(response.getIdentifier().isEmpty());
+      context.assertEquals("kb", response.getSource());
+      context.assertTrue(response.getLanguage().isEmpty());
+
+      async.complete();
+    }).exceptionally(throwable -> {
+      context.fail(throwable);
+      async.complete();
+      return null;
+    });
+  }
+
 
   /**
    * Test method for {@link org.folio.codex.RMAPIToCodex#getInstances(org.folio.cql2rmapi.CQLParserForRMAPI, io.vertx.core.Context, org.folio.config.RMAPIConfiguration)}.

--- a/src/test/java/org/folio/rmapi/RMAPIServiceTest.java
+++ b/src/test/java/org/folio/rmapi/RMAPIServiceTest.java
@@ -149,6 +149,10 @@ public class RMAPIServiceTest {
       context.assertEquals(1, rmapiResult.contributorsList.size());
       context.assertEquals("Quinn, Harper", rmapiResult.contributorsList.get(0).titleContributor);
       context.assertEquals("author", rmapiResult.contributorsList.get(0).type);
+      context.assertNotNull(rmapiResult.subjectsList);
+      context.assertEquals(1, rmapiResult.subjectsList.size());
+      context.assertEquals("MEDICAL / Physician & Patient", rmapiResult.subjectsList.get(0).titleSubject);
+      context.assertEquals("BISAC", rmapiResult.subjectsList.get(0).type);
       async.complete();
     }).exceptionally(throwable -> {
       context.fail(throwable);


### PR DESCRIPTION
## Purpose
Per https://issues.folio.org/browse/MODCXEKB-68, we want to support returning "subject" a.k.a "subjectsList" in RM API in response from Codex. This PR adds support for that.

## Approach
- Map "subjectsList" in RM API to "subject" in codex response.
- "subjectsList" in RM API is an array containing objects of "type" and "subject" which we are mapping to "subject" array containing objects of "type" and "name" in codex and returning in response.
- Add associated unit tests