### PR TITLE
Release 1.1.0 for Q4 Release

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,10 @@
+## 1.1.0 2018-12-04
+ * [MODCXEKB-64] - Update mod-codex-ekb to support Boolean/Exact Phrase/Wildcard/Nested Searches
+ * [MODCXEKB-67] - Upgrade mod-codex-ekb to RAML 1.0
+ * [MODCXEKB-68] - Return Subjects in mod-codex-ekb response
+ * [MODCXEKB-69] - Support search by subject
+
+
 ## 1.0.0 2018-05-17
  * MODCXEKB-63: Higher API limits required changes to RM API paging.
  * MODCXEKB-61: Updated the ModuleDescriptor to contain mod-configuration

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.folio</groupId>
   <artifactId>mod-codex-ekb</artifactId>
-  <version>1.0.1-SNAPSHOT</version>
+  <version>1.1.0</version>
 
   <name>EBSCO Knowledge Base Codex Module</name>
   <url>https://github.com/folio-org/mod-codex-ekb</url>


### PR DESCRIPTION
## Purpose
Per https://issues.folio.org/browse/MODCXEKB-70 - release module as part of Q4 release

## Approach
- Added version 1.1.0 to project -- https://issues.folio.org/projects/MODCXEKB?selectedItem=com.atlassian.jira.jira-projects-plugin:release-page&status=all
- Reference Jira issues in news and update pom.xml with release version
- Once merged to master, create release