### PR TITLE
MODCXMUX-30: Update subproject to include RAML for Codex packages

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -35,6 +35,9 @@
           "pathPattern" : "/codex-packages/{id}",
           "permissionsRequired" : [ "codex.packages.item.get" ],
           "modulePermissions": ["configuration.entries.collection.get"]
+        }, {
+          "methods" : [ "GET" ],
+          "pathPattern" : "/codex-packages-sources"
         }
       ]
     }

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -19,6 +19,24 @@
           "modulePermissions": ["configuration.entries.collection.get"]
         }
       ]
+    },
+    {
+      "id" : "codex-packages",
+      "version" : "1.0",
+      "interfaceType": "multiple",
+      "handlers" : [
+        {
+          "methods" : [ "GET" ],
+          "pathPattern" : "/codex-packages",
+          "permissionsRequired" : [ "codex.packages.collection.get" ],
+          "modulePermissions": ["configuration.entries.collection.get"]
+        }, {
+          "methods" : [ "GET" ],
+          "pathPattern" : "/codex-packages/{id}",
+          "permissionsRequired" : [ "codex.packages.item.get" ],
+          "modulePermissions": ["configuration.entries.collection.get"]
+        }
+      ]
     }
   ],
   "requires": [
@@ -36,13 +54,24 @@
       "permissionName" : "codex.item.get",
       "displayName" : "Codex - get individual instance",
       "description" : "Get individual instance"
+    },
+    {
+      "permissionName" : "codex.packages.collection.get",
+      "displayName" : "Codex - get packages",
+      "description" : "Get package collection"
+    }, {
+      "permissionName" : "codex.packages.item.get",
+      "displayName" : "Codex - get individual package",
+      "description" : "Get individual package"
     }, {
       "permissionName" : "codex.all",
       "displayName" : "Codex - all permissions",
       "description" : "Entire set of permissions needed to use the codex module",
       "subPermissions" : [
         "codex.collection.get",
-        "codex.item.get"
+        "codex.item.get",
+        "codex.packages.collection.get",
+        "codex.packages.item.get"
       ]
     }
   ],

--- a/src/main/java/org/folio/rest/impl/CodexPackagesImpl.java
+++ b/src/main/java/org/folio/rest/impl/CodexPackagesImpl.java
@@ -5,13 +5,15 @@ import io.vertx.core.Context;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import org.folio.rest.jaxrs.resource.CodexPackages;
+import org.folio.rest.jaxrs.resource.CodexPackagesSources;
+
 import javax.ws.rs.core.Response;
 import java.util.Map;
 
 /**
  * Package related codex APIs.
  */
-public final class CodexPackagesImpl implements CodexPackages {
+public final class CodexPackagesImpl implements CodexPackages, CodexPackagesSources {
 
   @Override
   public void getCodexPackages(String query, int offset, int limit, String lang, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
@@ -20,6 +22,11 @@ public final class CodexPackagesImpl implements CodexPackages {
 
   @Override
   public void getCodexPackagesById(String id, String lang, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
+    asyncResultHandler.handle(Future.succeededFuture(Response.status(Response.Status.NOT_IMPLEMENTED).build()));
+  }
+
+  @Override
+  public void getCodexPackagesSources(String lang, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
     asyncResultHandler.handle(Future.succeededFuture(Response.status(Response.Status.NOT_IMPLEMENTED).build()));
   }
 }

--- a/src/main/java/org/folio/rest/impl/CodexPackagesImpl.java
+++ b/src/main/java/org/folio/rest/impl/CodexPackagesImpl.java
@@ -1,0 +1,29 @@
+package org.folio.rest.impl;
+
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Context;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
+import org.folio.rest.jaxrs.resource.CodexPackages;
+import javax.ws.rs.core.Response;
+import java.util.Map;
+
+/**
+ * Package related codex APIs.
+ */
+public final class CodexPackagesImpl implements CodexPackages {
+  private final Logger log = LoggerFactory.getLogger(CodexPackagesImpl.class);
+
+
+  @Override
+  public void getCodexPackages(String query, int offset, int limit, String lang, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
+    asyncResultHandler.handle(Future.succeededFuture(Response.status(Response.Status.NOT_IMPLEMENTED).build()));
+  }
+
+  @Override
+  public void getCodexPackagesById(String id, String lang, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
+    asyncResultHandler.handle(Future.succeededFuture(Response.status(Response.Status.NOT_IMPLEMENTED).build()));
+  }
+}

--- a/src/main/java/org/folio/rest/impl/CodexPackagesImpl.java
+++ b/src/main/java/org/folio/rest/impl/CodexPackagesImpl.java
@@ -4,8 +4,6 @@ import io.vertx.core.AsyncResult;
 import io.vertx.core.Context;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
-import io.vertx.core.logging.Logger;
-import io.vertx.core.logging.LoggerFactory;
 import org.folio.rest.jaxrs.resource.CodexPackages;
 import javax.ws.rs.core.Response;
 import java.util.Map;
@@ -14,8 +12,6 @@ import java.util.Map;
  * Package related codex APIs.
  */
 public final class CodexPackagesImpl implements CodexPackages {
-  private final Logger log = LoggerFactory.getLogger(CodexPackagesImpl.class);
-
 
   @Override
   public void getCodexPackages(String query, int offset, int limit, String lang, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {


### PR DESCRIPTION
## Purpose
Per https://issues.folio.org/browse/MODCXMUX-30, we have added common definitions for Packages to Codex RAML (https://github.com/folio-org/raml/pull/114)
Update RAML subproject in mod-codex-ekb to get these latest changes.
Added placeholder methods for getCodexPackages and getCodexPackagesById.
Preliminary updates for module descriptor with add codex-packages interface.

## Approach
Steps to perform update are:
* cd ramls/raml-util
* git fetch
* git checkout raml1.0
* cd ../..
* git add ramls/raml-util
Also noted in prior PR - https://github.com/folio-org/mod-codex-ekb/pull/78

## To Dos/ Open Question:
[] Need to add permissions for getCodexPackagesSources as part of /codex-packages/ interfaces. To be handled in follow on ticket and PR
