### PR TITLE
MODCXEKB-83  Revise RMAPI To Codex to Handle Packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /.settings/
 /.classpath
 /.project
+.idea/

--- a/pom.xml
+++ b/pom.xml
@@ -108,6 +108,11 @@
       <artifactId>domain-models-runtime</artifactId>
       <version>${rmb.version}</version>
     </dependency>
+    <dependency>
+      <groupId>org.folio</groupId>
+      <artifactId>folio-di-support</artifactId>
+      <version>1.0.0</version>
+    </dependency>
     <!-- According to https://github.com/rest-assured/rest-assured/wiki/GettingStarted, rest assured should be placed before junit to ensure correct version of Hamcrest is used.-->
     <dependency>
       <groupId>io.rest-assured</groupId>
@@ -135,6 +140,12 @@
       <groupId>au.com.dius</groupId>
       <artifactId>pact-jvm-consumer-java8_2.12</artifactId>
       <version>${pact.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>2.24.5</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/src/main/java/org/folio/codex/IdentifierSubType.java
+++ b/src/main/java/org/folio/codex/IdentifierSubType.java
@@ -7,28 +7,27 @@ import java.util.Map;
  * @author mreno
  *
  */
-enum Type {
+public enum IdentifierSubType {
   UNKNOWN(-1, ""),
-  ISSN(0, "ISSN"),
-  ISBN(1, "ISBN"),
-  ZDBID(6, "ZDBID");
+  PRINT(1, "Print"),
+  ONLINE(2, "Online");
 
-  private static final Map<Integer, Type> MAP = new HashMap<>();
+  private static final Map<Integer, IdentifierSubType> MAP = new HashMap<>();
 
   static {
-    for (Type id : Type.values()) {
+    for (IdentifierSubType id : IdentifierSubType.values()) {
       MAP.put(id.code, id);
     }
   }
 
-  static Type valueOf(Integer i) {
+  public static IdentifierSubType valueOf(Integer i) {
     return MAP.getOrDefault(i, UNKNOWN);
   }
 
   private final int code;
   private final String displayName;
 
-  Type(int code, String displayName) {
+  IdentifierSubType(int code, String displayName) {
     this.code = code;
     this.displayName = displayName;
   }

--- a/src/main/java/org/folio/codex/IdentifierType.java
+++ b/src/main/java/org/folio/codex/IdentifierType.java
@@ -7,27 +7,28 @@ import java.util.Map;
  * @author mreno
  *
  */
-enum SubType {
+public enum IdentifierType {
   UNKNOWN(-1, ""),
-  PRINT(1, "Print"),
-  ONLINE(2, "Online");
+  ISSN(0, "ISSN"),
+  ISBN(1, "ISBN"),
+  ZDBID(6, "ZDBID");
 
-  private static final Map<Integer, SubType> MAP = new HashMap<>();
+  private static final Map<Integer, IdentifierType> MAP = new HashMap<>();
 
   static {
-    for (SubType id : SubType.values()) {
+    for (IdentifierType id : IdentifierType.values()) {
       MAP.put(id.code, id);
     }
   }
 
-  static SubType valueOf(Integer i) {
+  public static IdentifierType valueOf(Integer i) {
     return MAP.getOrDefault(i, UNKNOWN);
   }
 
   private final int code;
   private final String displayName;
 
-  SubType(int code, String displayName) {
+  IdentifierType(int code, String displayName) {
     this.code = code;
     this.displayName = displayName;
   }

--- a/src/main/java/org/folio/codex/PubType.java
+++ b/src/main/java/org/folio/codex/PubType.java
@@ -51,7 +51,7 @@ public enum PubType {
     final PubType result = map.get(value);
 
     if (result == null) {
-      throw new IllegalArgumentException("Unknown Resource IdentifierType: " + value);
+      throw new IllegalArgumentException("Unknown publication type: " + value);
     }
 
     return result;

--- a/src/main/java/org/folio/codex/PubType.java
+++ b/src/main/java/org/folio/codex/PubType.java
@@ -51,7 +51,7 @@ public enum PubType {
     final PubType result = map.get(value);
 
     if (result == null) {
-      throw new IllegalArgumentException("Unknown Resource Type: " + value);
+      throw new IllegalArgumentException("Unknown Resource IdentifierType: " + value);
     }
 
     return result;

--- a/src/main/java/org/folio/converter/hld2cdx/ContributorConverter.java
+++ b/src/main/java/org/folio/converter/hld2cdx/ContributorConverter.java
@@ -1,0 +1,17 @@
+package org.folio.converter.hld2cdx;
+
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.lang.NonNull;
+
+import org.folio.rest.jaxrs.model.Contributor;
+
+public class ContributorConverter implements Converter<org.folio.rmapi.model.Contributor, Contributor> {
+
+  @Override
+  public Contributor convert(@NonNull org.folio.rmapi.model.Contributor source) {
+    return new Contributor()
+      .withName(source.titleContributor)
+      .withType(source.type);
+  }
+
+}

--- a/src/main/java/org/folio/converter/hld2cdx/CoverageConverter.java
+++ b/src/main/java/org/folio/converter/hld2cdx/CoverageConverter.java
@@ -1,0 +1,18 @@
+package org.folio.converter.hld2cdx;
+
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.lang.NonNull;
+
+import org.folio.rest.jaxrs.model.Coverage;
+import org.folio.rmapi.model.CoverageDates;
+
+public class CoverageConverter implements Converter<CoverageDates, Coverage> {
+
+  @Override
+  public Coverage convert(@NonNull CoverageDates source) {
+    return new Coverage()
+      .withBeginCoverage(source.beginCoverage)
+      .withEndCoverage(source.endCoverage);
+  }
+
+}

--- a/src/main/java/org/folio/converter/hld2cdx/IdentifierConverter.java
+++ b/src/main/java/org/folio/converter/hld2cdx/IdentifierConverter.java
@@ -1,0 +1,35 @@
+package org.folio.converter.hld2cdx;
+
+import org.folio.codex.IdentifierSubType;
+import org.folio.codex.IdentifierType;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.lang.NonNull;
+
+import org.folio.rest.jaxrs.model.Identifier;
+
+public class IdentifierConverter implements Converter<org.folio.rmapi.model.Identifier, Identifier> {
+
+  @Override
+  public Identifier convert(@NonNull org.folio.rmapi.model.Identifier source) {
+    final IdentifierType type = IdentifierType.valueOf(source.type);
+    final IdentifierSubType subType = IdentifierSubType.valueOf(source.subtype);
+
+    final Identifier codexIdentifier;
+    if (type != IdentifierType.UNKNOWN) {
+      String codexType = type.getDisplayName();
+
+      if (subType != IdentifierSubType.UNKNOWN) {
+        codexType += '(' + subType.getDisplayName() + ')';
+      }
+
+      codexIdentifier = new Identifier()
+        .withType(codexType)
+        .withValue(source.id);
+    } else {
+      codexIdentifier = null;
+    }
+
+    return codexIdentifier;
+  }
+
+}

--- a/src/main/java/org/folio/converter/hld2cdx/PackageConverter.java
+++ b/src/main/java/org/folio/converter/hld2cdx/PackageConverter.java
@@ -1,0 +1,57 @@
+package org.folio.converter.hld2cdx;
+
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.lang.NonNull;
+
+import org.folio.codex.ContentType;
+import org.folio.rest.jaxrs.model.Coverage;
+import org.folio.rest.jaxrs.model.Package;
+import org.folio.rmapi.model.CoverageDates;
+import org.folio.rmapi.model.PackageData;
+
+public class PackageConverter implements Converter<PackageData, Package> {
+
+  private Converter<CoverageDates, Coverage> coverageConverter;
+
+
+  public PackageConverter(Converter<CoverageDates, Coverage> coverageConverter) {
+    this.coverageConverter = coverageConverter;
+  }
+
+  @Override
+  public Package convert(@NonNull PackageData source) {
+    Package result = new Package();
+
+    if (source.vendorId == null) {
+      throw new IllegalArgumentException("Vendor id cannot be null");
+    }
+    if (source.packageId == null) {
+      throw new IllegalArgumentException("Package id cannot be null");
+    }
+
+    result.setId(source.vendorId + "-" + source.packageId);
+
+    result.setIsSelected(convertSelected(source.isSelected));
+    if (source.customCoverage != null) {
+      result.setCoverage(coverageConverter.convert(source.customCoverage));
+    }
+    result.setItemCount(source.titleCount);
+    result.setName(source.packageName);
+    result.setProvider(source.vendorName);
+    result.setProviderId(Integer.toString(source.vendorId));
+    result.setSource("kb");
+    result.setType(ContentType.fromRMAPI(StringUtils.defaultString(source.contentType)).getCodex());
+
+    return result;
+  }
+
+  private Package.IsSelected convertSelected(Boolean isSelected) {
+    if (isSelected == null) {
+      return Package.IsSelected.NOT_SPECIFIED;
+    } else {
+      return isSelected ? Package.IsSelected.YES : Package.IsSelected.NO;
+    }
+  }
+
+}

--- a/src/main/java/org/folio/converter/hld2cdx/SubjectConverter.java
+++ b/src/main/java/org/folio/converter/hld2cdx/SubjectConverter.java
@@ -1,0 +1,16 @@
+package org.folio.converter.hld2cdx;
+
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.lang.NonNull;
+
+import org.folio.rest.jaxrs.model.Subject;
+
+public class SubjectConverter implements Converter<org.folio.rmapi.model.Subject, Subject> {
+
+  @Override
+  public Subject convert(@NonNull org.folio.rmapi.model.Subject source) {
+    return new Subject()
+      .withName(source.titleSubject)
+      .withType(source.type);
+  }
+}

--- a/src/main/java/org/folio/converter/hld2cdx/TitleConverter.java
+++ b/src/main/java/org/folio/converter/hld2cdx/TitleConverter.java
@@ -1,0 +1,75 @@
+package org.folio.converter.hld2cdx;
+
+import static java.util.stream.Collectors.toSet;
+import static org.apache.commons.collections4.CollectionUtils.isNotEmpty;
+
+import java.util.Objects;
+import java.util.Set;
+
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.lang.NonNull;
+
+import org.folio.codex.PubType;
+import org.folio.rest.jaxrs.model.Contributor;
+import org.folio.rest.jaxrs.model.Identifier;
+import org.folio.rest.jaxrs.model.Instance;
+import org.folio.rest.jaxrs.model.Subject;
+import org.folio.rmapi.model.Title;
+
+public class TitleConverter implements Converter<Title, Instance> {
+
+  private static final String E_RESOURCE_FORMAT = "Electronic Resource";
+  private static final String E_RESOURCE_SOURCE = "kb";
+
+  private Converter<org.folio.rmapi.model.Identifier, Identifier> identifierConverter;
+  private Converter<org.folio.rmapi.model.Contributor, Contributor> contributorConverter;
+  private Converter<org.folio.rmapi.model.Subject, Subject> subjectConverter;
+
+
+  public TitleConverter(Converter<org.folio.rmapi.model.Identifier, Identifier> identifierConverter,
+                        Converter<org.folio.rmapi.model.Contributor, Contributor> contributorConverter,
+                        Converter<org.folio.rmapi.model.Subject, Subject> subjectConverter) {
+    this.identifierConverter = identifierConverter;
+    this.contributorConverter = contributorConverter;
+    this.subjectConverter = subjectConverter;
+  }
+
+  @Override
+  public Instance convert(@NonNull Title source) {
+    final Instance codexInstance = new Instance();
+
+    codexInstance.setId(Integer.toString(source.titleId));
+    codexInstance.setTitle(source.titleName);
+    codexInstance.setPublisher(source.publisherName);
+    codexInstance.setType(PubType.fromRMAPI(source.pubType).getCodex());
+    codexInstance.setFormat(E_RESOURCE_FORMAT);
+    codexInstance.setSource(E_RESOURCE_SOURCE);
+    codexInstance.setVersion(source.edition);
+
+    if (isNotEmpty(source.identifiersList)) {
+      final Set<Identifier> identifiers = source.identifiersList.stream()
+        .map(identifierConverter::convert)
+        .filter(Objects::nonNull)
+        .collect(toSet());
+
+      if (!identifiers.isEmpty()) {
+        codexInstance.setIdentifier(identifiers);
+      }
+    }
+
+    if (isNotEmpty(source.contributorsList)) {
+      codexInstance.setContributor(source.contributorsList.stream()
+        .map(contributorConverter::convert)
+        .collect(toSet()));
+    }
+
+    if (isNotEmpty(source.subjectsList)) {
+      codexInstance.setSubject(source.subjectsList.stream()
+        .map(subjectConverter::convert)
+        .collect(toSet()));
+    }
+
+    return codexInstance;
+  }
+
+}

--- a/src/main/java/org/folio/rmapi/RMAPIService.java
+++ b/src/main/java/org/folio/rmapi/RMAPIService.java
@@ -2,15 +2,15 @@ package org.folio.rmapi;
 
 import java.util.concurrent.CompletableFuture;
 
-import org.folio.rmapi.model.Title;
-import org.folio.rmapi.model.Titles;
-
 import io.vertx.core.Vertx;
 import io.vertx.core.http.HttpClient;
 import io.vertx.core.http.HttpClientRequest;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
+
+import org.folio.rmapi.model.Title;
+import org.folio.rmapi.model.Titles;
 
 /**
  * @author cgodfrey
@@ -79,7 +79,7 @@ public class RMAPIService {
           future.complete((T) results);
         } catch (Exception e) {
           LOG.error(
-              String.format("%s - Response = [%s] Target Type = [%s]", JSON_RESPONSE_ERROR, body.toString(), clazz));
+              String.format("%s - Response = [%s] Target IdentifierType = [%s]", JSON_RESPONSE_ERROR, body.toString(), clazz));
           future.completeExceptionally(
               new RMAPIResultsProcessingException(String.format("%s for query = %s", JSON_RESPONSE_ERROR, query), e));
         } finally {

--- a/src/main/java/org/folio/rmapi/RMAPIService.java
+++ b/src/main/java/org/folio/rmapi/RMAPIService.java
@@ -79,7 +79,7 @@ public class RMAPIService {
           future.complete((T) results);
         } catch (Exception e) {
           LOG.error(
-              String.format("%s - Response = [%s] Target IdentifierType = [%s]", JSON_RESPONSE_ERROR, body.toString(), clazz));
+              String.format("%s - Response = [%s] Target Type = [%s]", JSON_RESPONSE_ERROR, body.toString(), clazz));
           future.completeExceptionally(
               new RMAPIResultsProcessingException(String.format("%s for query = %s", JSON_RESPONSE_ERROR, query), e));
         } finally {

--- a/src/main/java/org/folio/rmapi/model/PackageData.java
+++ b/src/main/java/org/folio/rmapi/model/PackageData.java
@@ -1,0 +1,36 @@
+package org.folio.rmapi.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class PackageData {
+  @JsonProperty("packageId")
+  public Integer packageId;
+  @JsonProperty("packageName")
+  public String packageName;
+  @JsonProperty("vendorId")
+  public Integer vendorId;
+  @JsonProperty("vendorName")
+  public String vendorName;
+  @JsonProperty("isCustom")
+  public Boolean isCustom;
+  @JsonProperty("titleCount")
+  public Integer titleCount;
+  @JsonProperty("isSelected")
+  public Boolean isSelected;
+  @JsonProperty("selectedCount")
+  public Integer selectedCount;
+  @JsonProperty("contentType")
+  public String contentType;
+  @JsonProperty("visibilityData")
+  public VisibilityInfo visibilityData;
+  @JsonProperty("customCoverage")
+  public CoverageDates customCoverage;
+  @JsonProperty("isTokenNeeded")
+  public Boolean isTokenNeeded;
+  @JsonProperty("allowEbscoToAddTitles")
+  public Boolean allowEbscoToAddTitles;
+  @JsonProperty("packageType")
+  public String packageType;
+}

--- a/src/test/java/org/folio/codex/RMAPIToCodexTest.java
+++ b/src/test/java/org/folio/codex/RMAPIToCodexTest.java
@@ -11,25 +11,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.CompletionException;
 
-import org.folio.config.RMAPIConfiguration;
-import org.folio.cql2rmapi.CQLParameters;
-import org.folio.cql2rmapi.QueryValidationException;
-import org.folio.cql2rmapi.TitleParameters;
-import org.folio.cql2rmapi.query.RMAPIQueries;
-import org.folio.cql2rmapi.query.TitlesQueryBuilder;
-import org.folio.rest.RestVerticle;
-import org.folio.rest.jaxrs.model.Contributor;
-import org.folio.rest.jaxrs.model.Subject;
-import org.folio.rest.jaxrs.model.Identifier;
-import org.folio.rest.jaxrs.model.Instance;
-import org.folio.rest.tools.client.test.HttpClientMock2;
-import org.folio.rmapi.RMAPIResourceNotFoundException;
-import org.folio.utils.Utils;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-
 import io.vertx.core.DeploymentOptions;
 import io.vertx.core.Vertx;
 import io.vertx.core.http.HttpServer;
@@ -40,6 +21,25 @@ import io.vertx.core.logging.LoggerFactory;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.folio.config.RMAPIConfiguration;
+import org.folio.cql2rmapi.CQLParameters;
+import org.folio.cql2rmapi.QueryValidationException;
+import org.folio.cql2rmapi.TitleParameters;
+import org.folio.cql2rmapi.query.RMAPIQueries;
+import org.folio.cql2rmapi.query.TitlesQueryBuilder;
+import org.folio.rest.RestVerticle;
+import org.folio.rest.jaxrs.model.Contributor;
+import org.folio.rest.jaxrs.model.Identifier;
+import org.folio.rest.jaxrs.model.Instance;
+import org.folio.rest.jaxrs.model.Subject;
+import org.folio.rest.tools.client.test.HttpClientMock2;
+import org.folio.rmapi.RMAPIResourceNotFoundException;
+import org.folio.utils.Utils;
 
 /**
  * @author mreno
@@ -549,11 +549,11 @@ public class RMAPIToCodexTest {
 
   @Test
   public void typeAndSubTypeTest(TestContext context) {
-    context.assertEquals("ISSN", Type.ISSN.getDisplayName());
-    context.assertEquals(0, Type.ISSN.getCode());
+    context.assertEquals("ISSN", IdentifierType.ISSN.getDisplayName());
+    context.assertEquals(0, IdentifierType.ISSN.getCode());
 
-    context.assertEquals("Print", SubType.PRINT.getDisplayName());
-    context.assertEquals(1, SubType.PRINT.getCode());
+    context.assertEquals("Print", IdentifierSubType.PRINT.getDisplayName());
+    context.assertEquals(1, IdentifierSubType.PRINT.getCode());
   }
 
   @Test

--- a/src/test/java/org/folio/converter/hld2cdx/CoverageConverterTest.java
+++ b/src/test/java/org/folio/converter/hld2cdx/CoverageConverterTest.java
@@ -1,0 +1,54 @@
+package org.folio.converter.hld2cdx;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import org.folio.rest.jaxrs.model.Coverage;
+import org.folio.rmapi.model.CoverageDates;
+
+public class CoverageConverterTest {
+
+  private static final String BEGIN_COVERAGE = "2019-01-01";
+  private static final String END_COVERAGE = "2019-02-01";
+
+  private CoverageConverter converter;
+
+  @Before
+  public void setUp() {
+    converter = new CoverageConverter();
+  }
+
+  @Test
+  public void shouldCopyDates() {
+    Coverage converted = converter.convert(coverage(BEGIN_COVERAGE, END_COVERAGE));
+
+    assertNotNull(converted);
+    assertEquals(BEGIN_COVERAGE, converted.getBeginCoverage());
+    assertEquals(END_COVERAGE, converted.getEndCoverage());
+  }
+
+  @Test(expected = NullPointerException.class)
+  public void shouldThrowNPEIfInputIsNull() {
+    converter.convert(null);
+  }
+
+  @Test
+  public void shouldAcceptNullDates() {
+    Coverage converted = converter.convert(coverage(null, null));
+
+    assertNotNull(converted);
+    assertNull(converted.getBeginCoverage());
+    assertNull(converted.getEndCoverage());
+  }
+
+  private CoverageDates coverage(String begin, String end) {
+    CoverageDates input = new CoverageDates();
+    input.beginCoverage = begin;
+    input.endCoverage = end;
+    return input;
+  }
+}

--- a/src/test/java/org/folio/converter/hld2cdx/PackageConverterTest.java
+++ b/src/test/java/org/folio/converter/hld2cdx/PackageConverterTest.java
@@ -1,0 +1,146 @@
+package org.folio.converter.hld2cdx;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.mockito.Mockito.when;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.core.convert.converter.Converter;
+
+import org.folio.rest.jaxrs.model.Coverage;
+import org.folio.rest.jaxrs.model.Package;
+import org.folio.rmapi.model.CoverageDates;
+import org.folio.rmapi.model.PackageData;
+
+@RunWith(MockitoJUnitRunner.StrictStubs.class)
+public class PackageConverterTest {
+
+  private static final Integer PACKAGE_ID = 111;
+  private static final Integer VENDOR_ID = 222;
+  private static final String PACKAGE_NAME = "Package name";
+  private static final String PACKAGE_TYPE_EBOOK = "EBook";
+  private static final Integer TITLE_COUNT = 100;
+  private static final String VENDOR_NAME = "Vendor";
+  private static final CoverageDates COVERAGE_DATES = new CoverageDates();
+  private static final Coverage COVERAGE = new Coverage();
+
+  private static final String PACKAGE_UUID = VENDOR_ID + "-" + PACKAGE_ID;
+  private static final String SOURCE = "kb";
+
+  @Mock
+  private Converter<CoverageDates, Coverage> coverageConverter;
+  @InjectMocks
+  private PackageConverter converter;
+
+
+  @Test
+  public void shouldConvertPackageData() {
+    when(coverageConverter.convert(COVERAGE_DATES)).thenReturn(COVERAGE);
+
+    PackageData input = createBasePackageData();
+
+    Package converted = converter.convert(input);
+
+    assertNotNull(converted);
+    assertEquals(PACKAGE_UUID, converted.getId());
+    assertEquals(Package.IsSelected.NO, converted.getIsSelected());
+    assertEquals(TITLE_COUNT, converted.getItemCount());
+    assertEquals(PACKAGE_NAME, converted.getName());
+    assertEquals(VENDOR_NAME, converted.getProvider());
+    assertEquals(VENDOR_ID.toString(), converted.getProviderId());
+    assertEquals(SOURCE, converted.getSource());
+    assertEquals(Package.Type.E_BOOK, converted.getType());
+    assertSame(COVERAGE, converted.getCoverage());
+  }
+
+  @Test
+  public void shouldIgnoreEmptyCoverage() {
+    PackageData input = createBasePackageData();
+    input.customCoverage = null;
+
+    Package converted = converter.convert(input);
+
+    assertNotNull(converted);
+    assertNull(converted.getCoverage());
+  }
+
+  @Test
+  public void shouldSetSelectedToNotSpecifiedIfNull() {
+    PackageData input = createBasePackageData();
+    input.isSelected = null;
+
+    Package converted = converter.convert(input);
+
+    assertNotNull(converted);
+    assertEquals(Package.IsSelected.NOT_SPECIFIED, converted.getIsSelected());
+  }
+
+  @Test
+  public void shouldSetSelectedToYesIfTrue() {
+    PackageData input = createBasePackageData();
+    input.isSelected = true;
+
+    Package converted = converter.convert(input);
+
+    assertNotNull(converted);
+    assertEquals(Package.IsSelected.YES, converted.getIsSelected());
+  }
+
+  @Test(expected = NullPointerException.class)
+  public void shouldThrowNPEIfInputIsNull() {
+    converter.convert(null);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void shouldThrowIllegalArgExcIfVendorIdIsNull() {
+    PackageData input = createBasePackageData();
+    input.vendorId = null;
+
+    converter.convert(input);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void shouldThrowIllegalArgExcIfPackageIdIsNull() {
+    PackageData input = createBasePackageData();
+    input.packageId = null;
+
+    converter.convert(input);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void shouldThrowIllegalArgExcIfContentTypeInvalid() {
+    PackageData input = createBasePackageData();
+    input.contentType = "ABCD";
+
+    converter.convert(input);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void shouldThrowIllegalArgExcIfContentTypeNull() {
+    PackageData input = createBasePackageData();
+    input.contentType = null;
+
+    converter.convert(input);
+  }
+
+  private PackageData createBasePackageData() {
+    PackageData result = new PackageData();
+
+    result.packageId = PACKAGE_ID;
+    result.vendorId = VENDOR_ID;
+    result.vendorName = VENDOR_NAME;
+    result.isSelected = false;
+    result.packageName = PACKAGE_NAME;
+    result.contentType = PACKAGE_TYPE_EBOOK;
+    result.titleCount = TITLE_COUNT;
+    result.customCoverage = COVERAGE_DATES;
+
+    return result;
+  }
+}

--- a/src/test/java/org/folio/rest/impl/CodexInstanceResourceImplTest.java
+++ b/src/test/java/org/folio/rest/impl/CodexInstanceResourceImplTest.java
@@ -1,20 +1,12 @@
 package org.folio.rest.impl;
 
-import static org.folio.utils.Utils.readMockFile;
 import static org.hamcrest.Matchers.containsString;
+
+import static org.folio.utils.Utils.readMockFile;
 
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
-
-import org.folio.rest.RestVerticle;
-import org.folio.rest.tools.PomReader;
-import org.folio.rest.tools.client.test.HttpClientMock2;
-import org.folio.utils.Utils;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
 
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
@@ -29,6 +21,15 @@ import io.vertx.core.logging.LoggerFactory;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.folio.rest.RestVerticle;
+import org.folio.rest.tools.PomReader;
+import org.folio.rest.tools.client.test.HttpClientMock2;
+import org.folio.utils.Utils;
 
 @RunWith(VertxUnitRunner.class)
 public class CodexInstanceResourceImplTest {
@@ -47,7 +48,7 @@ public class CodexInstanceResourceImplTest {
 
   private final Header tenantHeader = new Header("X-Okapi-Tenant", "codexinstancesresourceimpltest");
   private final Header urlHeader = new Header("X-Okapi-Url", "https://localhost:" + okapiPort);
-  private final Header contentTypeHeader = new Header("Content-Type", "application/json");
+  private final Header contentTypeHeader = new Header("Content-IdentifierType", "application/json");
 
   private String moduleName;
   private String moduleVersion;

--- a/src/test/java/org/folio/rest/impl/CodexInstanceResourceImplTest.java
+++ b/src/test/java/org/folio/rest/impl/CodexInstanceResourceImplTest.java
@@ -48,7 +48,7 @@ public class CodexInstanceResourceImplTest {
 
   private final Header tenantHeader = new Header("X-Okapi-Tenant", "codexinstancesresourceimpltest");
   private final Header urlHeader = new Header("X-Okapi-Url", "https://localhost:" + okapiPort);
-  private final Header contentTypeHeader = new Header("Content-IdentifierType", "application/json");
+  private final Header contentTypeHeader = new Header("Content-Type", "application/json");
 
   private String moduleName;
   private String moduleVersion;


### PR DESCRIPTION
## Purpose
Implement transformation of HoldingsIQ packages to Codex packages

## Approach
- extract code which performs transformation of titles from RMAPIToCodex class to specific converter classes that implements `Converter<S, T>` interface (similarly to mod-kb-ebsco-java)
- implement Package converter according to mapping [Codex Search App  - Metadata Elements, Filters, Search and Sort](https://docs.google.com/spreadsheets/d/1GQhgG5PnXJguB8K_JagmIVYpxx8HwGdkU4Sn96Q6YJg/edit#gid=1804402370)