### PR TITLE
MODCXEKB-81 Implement /codex-packages-sources

### DIFF
--- a/src/main/java/org/folio/codex/ContentType.java
+++ b/src/main/java/org/folio/codex/ContentType.java
@@ -8,13 +8,13 @@ import org.folio.rest.jaxrs.model.Package;
 
 public enum ContentType {
 
-  AGGREGATED_FULL_TEXT(Package.Type.AGGREGATED_FULL_TEXT, "aggregatedfulltext"),
-  ABSTRACT_AND_INDEX(Package.Type.ABSTRACT_AND_INDEX, "abstractandindex"),
-  E_BOOK(Package.Type.E_BOOK, "ebook"),
-  E_JOURNAL(Package.Type.E_JOURNAL, "ejournal"),
+  AGGREGATED_FULL_TEXT(Package.Type.AGGREGATEDFULLTEXT, "aggregatedfulltext"),
+  ABSTRACT_AND_INDEX(Package.Type.ABSTRACTANDINDEX, "abstractandindex"),
+  E_BOOK(Package.Type.EBOOK, "ebook"),
+  E_JOURNAL(Package.Type.EJOURNAL, "ejournal"),
   PRINT(Package.Type.PRINT, "print"),
   UNKNOWN(Package.Type.UNKNOWN, "unknown"),
-  ONLINE_REFERENCE(Package.Type.ONLINE_REFERENCE, "onlinereference");
+  ONLINE_REFERENCE(Package.Type.ONLINEREFERENCE, "onlinereference");
 
   private final Package.Type codex;
   private final String rmAPI;

--- a/src/main/java/org/folio/rest/impl/CodexPackagesImpl.java
+++ b/src/main/java/org/folio/rest/impl/CodexPackagesImpl.java
@@ -1,19 +1,27 @@
 package org.folio.rest.impl;
 
+import java.util.Collections;
+import java.util.Map;
+
+import javax.ws.rs.core.Response;
+
+import org.folio.rest.jaxrs.model.Source;
+import org.folio.rest.jaxrs.model.SourceCollection;
+import org.folio.rest.jaxrs.resource.CodexPackages;
+import org.folio.rest.jaxrs.resource.CodexPackagesSources;
+import org.folio.rest.tools.PomReader;
+
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Context;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
-import org.folio.rest.jaxrs.resource.CodexPackages;
-import org.folio.rest.jaxrs.resource.CodexPackagesSources;
-
-import javax.ws.rs.core.Response;
-import java.util.Map;
 
 /**
  * Package related codex APIs.
  */
 public final class CodexPackagesImpl implements CodexPackages, CodexPackagesSources {
+
+  private static final String MODULE_SOURCE = "kb";
 
   @Override
   public void getCodexPackages(String query, int offset, int limit, String lang, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
@@ -27,6 +35,13 @@ public final class CodexPackagesImpl implements CodexPackages, CodexPackagesSour
 
   @Override
   public void getCodexPackagesSources(String lang, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
-    asyncResultHandler.handle(Future.succeededFuture(Response.status(Response.Status.NOT_IMPLEMENTED).build()));
+    String moduleName = PomReader.INSTANCE.getModuleName().replace("_", "-");
+    String moduleVersion = PomReader.INSTANCE.getVersion();
+    asyncResultHandler.handle(Future.succeededFuture(GetCodexPackagesSourcesResponse.respond200WithApplicationJson(new SourceCollection()
+      .withSources(Collections.singletonList(
+        new Source()
+          .withId(MODULE_SOURCE)
+          .withName(moduleName + "-" + moduleVersion)
+      )))));
   }
 }

--- a/src/test/java/org/folio/converter/hld2cdx/PackageConverterTest.java
+++ b/src/test/java/org/folio/converter/hld2cdx/PackageConverterTest.java
@@ -55,7 +55,7 @@ public class PackageConverterTest {
     assertEquals(VENDOR_NAME, converted.getProvider());
     assertEquals(VENDOR_ID.toString(), converted.getProviderId());
     assertEquals(SOURCE, converted.getSource());
-    assertEquals(Package.Type.E_BOOK, converted.getType());
+    assertEquals(Package.Type.EBOOK, converted.getType());
     assertSame(COVERAGE, converted.getCoverage());
   }
 

--- a/src/test/java/org/folio/cql2rmapi/PackageParametersTest.java
+++ b/src/test/java/org/folio/cql2rmapi/PackageParametersTest.java
@@ -7,7 +7,7 @@ import org.junit.Test;
 public class PackageParametersTest {
   private static final String SEARCH_VALUE = "bridget";
   private static final String VALID_NAME_QUERY = "name = bridget sortby name";
-  private static final String VALID_FILTER_QUERY = "name = bridget and type = Aggregated Full Text sortby name";
+  private static final String VALID_FILTER_QUERY = "name = bridget and type = aggregatedfulltext sortby name";
   private static final String VALID_SELECTED_QUERY = "(name = \"bridget\") and (ext.selected = true) sortby name";
 
   @Test(expected = QueryValidationException.class)

--- a/src/test/java/org/folio/rest/impl/CodexInstanceResourceImplTest.java
+++ b/src/test/java/org/folio/rest/impl/CodexInstanceResourceImplTest.java
@@ -4,35 +4,23 @@ import static org.folio.utils.Utils.readMockFile;
 import static org.hamcrest.Matchers.containsString;
 
 import java.io.IOException;
-import java.util.HashMap;
-import java.util.Map;
 
-import org.folio.rest.RestVerticle;
-import org.folio.rest.tools.PomReader;
-import org.folio.rest.tools.client.test.HttpClientMock2;
-import org.folio.utils.Utils;
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
-import io.restassured.http.Header;
 import io.restassured.response.Response;
-import io.vertx.core.DeploymentOptions;
-import io.vertx.core.Vertx;
 import io.vertx.core.http.HttpServer;
 import io.vertx.core.json.JsonObject;
-import io.vertx.core.logging.Logger;
-import io.vertx.core.logging.LoggerFactory;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
 
 @RunWith(VertxUnitRunner.class)
-public class CodexInstanceResourceImplTest {
-  private static final String MOCK_RMAPI_CONFIG_SUCCESS_FILE = "RMAPIToCodex/mock_content.json";
+public class CodexInstanceResourceImplTest extends VertxTestBase {
+
   private static final String MOCK_RMAPI_INSTANCE_TITLE_200_RESPONSE_WHEN_FOUND = "RMAPIService/SuccessGetTitleById.json";
   private static final String MOCK_RMAPI_INSTANCE_TITLE_404_RESPONSE_WHEN_NOT_FOUND = "RMAPIConfiguration/mock_content_fail_404.json";
   private static final String MOCK_CODEX_INSTANCE_TITLE_COLLECTION_200_RESPONSE_WHEN_FOUND = "RMAPIService/SuccessGetTitleList.json";
@@ -41,56 +29,24 @@ public class CodexInstanceResourceImplTest {
   private static final String SEARCH_TITLE_COLLECTION_WHEN_SEARCH_FIELD_NOT_GIVEN_SUCCESS_QUERY = "Bridget Jones";
   private static final String SEARCH_TITLE_COLLECTION_FAILS_UNSUPPORTED_QUERY = "title = Bridget Jones or publisher = xyz";
 
-  private final Logger logger = LoggerFactory.getLogger("CodexInstancesResourceImplTest");
-
-  private final int okapiPort = Utils.getRandomPort();
-
-  private final Header tenantHeader = new Header("X-Okapi-Tenant", "codexinstancesresourceimpltest");
-  private final Header urlHeader = new Header("X-Okapi-Url", "https://localhost:" + okapiPort);
-  private final Header contentTypeHeader = new Header("Content-Type", "application/json");
-
-  private String moduleName;
-  private String moduleVersion;
-  private String moduleId;
-  private Vertx vertx;
-  // This object is needed to modify RMAPIConfiguration's local
-  // object as a side effect.
-  private HttpClientMock2 httpClientMock;
-
   @Before
   public void setUp(TestContext context) {
-    vertx = Vertx.vertx();
-
-    moduleName = PomReader.INSTANCE.getModuleName().replaceAll("_", "-");
-    moduleVersion = PomReader.INSTANCE.getVersion();
-    moduleId = moduleName + "-" + moduleVersion;
-    logger.info("Test setup starting for " + moduleId);
-
-    final JsonObject conf = new JsonObject();
-    conf.put("http.port", okapiPort);
-    conf.put(HttpClientMock2.MOCK_MODE, "true");
-
-    final DeploymentOptions opt = new DeploymentOptions().setConfig(conf);
-    vertx.deployVerticle(RestVerticle.class.getName(), opt, context.asyncAssertSuccess());
-    RestAssured.port = okapiPort;
-    logger.info("Codex Instances Resource Test Setup Done using port " + okapiPort);
-
+    super.setUp(context);
+    final Async async = context.async();
     final int serverPort = Integer.parseInt(System.getProperty("serverPort", Integer.toString(51234)));
     final String host = "localhost";
-
-    final Async async = context.async();
     final HttpServer server = vertx.createHttpServer();
     server.requestHandler(req -> {
       if (req.path().equals(String.format("/rm/rmaccounts/test/titles/%s", "99999"))) {
         req.response().setStatusCode(200).putHeader("content-type", "application/json")
-            .end(readMockFile(MOCK_RMAPI_INSTANCE_TITLE_200_RESPONSE_WHEN_FOUND));
+          .end(readMockFile(MOCK_RMAPI_INSTANCE_TITLE_200_RESPONSE_WHEN_FOUND));
       } else if (req.path().equals(String.format("/rm/rmaccounts/test/titles/%s", "1"))) {
         req.response().setStatusCode(404).putHeader("content-type", "text/plain")
-            .end(readMockFile(MOCK_RMAPI_INSTANCE_TITLE_404_RESPONSE_WHEN_NOT_FOUND));
+          .end(readMockFile(MOCK_RMAPI_INSTANCE_TITLE_404_RESPONSE_WHEN_NOT_FOUND));
       } else if (req.path().equals("/rm/rmaccounts/test/titles")) {
         if (req.uri().contains("searchfield=titlename&search=Bridget+Jones&orderby=titlename&count=10&offset=1")) {
           req.response().setStatusCode(200).putHeader("content-type", "application/json")
-          .end(readMockFile(MOCK_CODEX_INSTANCE_TITLE_COLLECTION_200_RESPONSE_WHEN_FOUND));
+            .end(readMockFile(MOCK_CODEX_INSTANCE_TITLE_COLLECTION_200_RESPONSE_WHEN_FOUND));
         } else {
           req.response().setStatusCode(500).end("Unexpected call: " + req.path());
         }
@@ -98,32 +54,13 @@ public class CodexInstanceResourceImplTest {
         req.response().setStatusCode(500).end("Unexpected call: " + req.path());
       }
     });
-
     server.listen(serverPort, host, ar -> {
       async.complete();
     });
-
-    final Map<String, String> okapiHeaders = new HashMap<>();
-    okapiHeaders.put("X-Okapi-Tenant", "codexinstancesresourceimpltest");
-    okapiHeaders.put("X-Okapi-Url", "https://localhost:" + Integer.toString(okapiPort));
-    httpClientMock = new HttpClientMock2(okapiHeaders.get("X-Okapi-Tenant"), okapiHeaders.get("X-Okapi-Url"));
-    try {
-      // Mocking the RM API Configuration response
-      httpClientMock.setMockJsonContent(MOCK_RMAPI_CONFIG_SUCCESS_FILE);
-    } catch (final IOException e) {
-      context.fail("Cannot read mock file: " + MOCK_RMAPI_CONFIG_SUCCESS_FILE + " - reason: " + e.getMessage());
-    }
-  }
-
-  @After
-  public void tearDown(TestContext context) {
-    logger.info("Codex Instances Resource Testing Complete");
-    vertx.close(context.asyncAssertSuccess());
   }
 
   @Test
   public void getCodexInstancesByIdSuccessTest(TestContext context) {
-    final Async asyncLocal = context.async();
     logger.info("Testing for successful instance id");
 
     final Response r = RestAssured
@@ -145,12 +82,10 @@ public class CodexInstanceResourceImplTest {
 
     // Test done
     logger.info("Test done");
-    asyncLocal.complete();
   }
 
   @Test
   public void getCodexInstancesByIdThrowsExceptionWhenOkapiURLIsEmptyTest(TestContext context) {
-    final Async asyncLocal = context.async();
     logger.info("Test when Okapi URL is null is starting");
 
     RestAssured
@@ -165,12 +100,10 @@ public class CodexInstanceResourceImplTest {
 
     // Test done
     logger.info("Test done");
-    asyncLocal.complete();
   }
 
   @Test
   public void getCodexInstancesByIdTitleNotFoundTest(TestContext context) {
-    final Async asyncLocal = context.async();
     logger.info("Testing for response when title not found");
 
     RestAssured
@@ -186,12 +119,10 @@ public class CodexInstanceResourceImplTest {
 
     // Test done
     logger.info("Test done");
-    asyncLocal.complete();
   }
 
   @Test
   public void getCodexInstancesByIdTitleNotAuth(TestContext context) {
-    final Async asyncLocal = context.async();
     logger.info("Testing for response when not authorized");
 
     try {
@@ -214,12 +145,10 @@ public class CodexInstanceResourceImplTest {
 
     // Test done
     logger.info("Test done");
-    asyncLocal.complete();
   }
 
   @Test
   public void getCodexInstancesSuccessTest(TestContext context) {
-    final Async asyncLocal = context.async();
     logger.info("Testing for successful instance collection");
 
     final Response r = RestAssured
@@ -244,12 +173,10 @@ public class CodexInstanceResourceImplTest {
 
     // Test done
     logger.info("Test done");
-    asyncLocal.complete();
   }
 
   @Test
   public void getCodexInstancesIdSearchSuccessTest(TestContext context) {
-    final Async asyncLocal = context.async();
     logger.info("Testing for successful instance collection");
 
     final Response r = RestAssured
@@ -274,12 +201,10 @@ public class CodexInstanceResourceImplTest {
 
     // Test done
     logger.info("Test done");
-    asyncLocal.complete();
   }
 
   @Test
   public void getCodexInstancesIdSearchFailTest(TestContext context) {
-    final Async asyncLocal = context.async();
     logger.info("Testing for successful instance collection");
 
     final Response r = RestAssured
@@ -304,12 +229,10 @@ public class CodexInstanceResourceImplTest {
 
     // Test done
     logger.info("Test done");
-    asyncLocal.complete();
   }
 
   @Test
   public void getCodexInstancesHandlesInvalidQueryTest(TestContext context) {
-    final Async asyncLocal = context.async();
     logger.info("Test when query is invalid, exception is thrown");
 
     RestAssured
@@ -325,12 +248,10 @@ public class CodexInstanceResourceImplTest {
 
     // Test done
     logger.info("Test done");
-    asyncLocal.complete();
   }
 
   @Test
   public void getCodexInstancesHandlesUnsupportedQueryTest(TestContext context) {
-    final Async asyncLocal = context.async();
     logger.info("Test when query is invalid, exception is thrown");
 
     RestAssured
@@ -346,6 +267,5 @@ public class CodexInstanceResourceImplTest {
 
     // Test done
     logger.info("Test done");
-    asyncLocal.complete();
   }
 }

--- a/src/test/java/org/folio/rest/impl/CodexPackagesImplTest.java
+++ b/src/test/java/org/folio/rest/impl/CodexPackagesImplTest.java
@@ -1,0 +1,44 @@
+package org.folio.rest.impl;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.List;
+
+import org.folio.rest.jaxrs.model.Source;
+import org.folio.rest.jaxrs.model.SourceCollection;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+
+@RunWith(VertxUnitRunner.class)
+public class CodexPackagesImplTest extends VertxTestBase {
+
+  @Test
+  public void getCodexPackagesSourcesSuccessTest() {
+    logger.info("Testing for successful instance id");
+
+    final SourceCollection response = RestAssured
+      .given()
+      .header(tenantHeader)
+      .header(urlHeader)
+      .header(contentTypeHeader)
+      .get("/codex-packages-sources")
+      .then()
+      .contentType(ContentType.JSON)
+      .log()
+      .ifValidationFails()
+      .statusCode(200).extract().as(SourceCollection.class);
+
+    List<Source> sources = response.getSources();
+    assertEquals(1, sources.size());
+    assertTrue(sources.get(0).getName().matches("mod-codex-ekb-.*"));
+    assertTrue(sources.get(0).getId().matches("kb"));
+
+    logger.info("Test done");
+  }
+
+}

--- a/src/test/java/org/folio/rest/impl/VertxTestBase.java
+++ b/src/test/java/org/folio/rest/impl/VertxTestBase.java
@@ -1,0 +1,73 @@
+package org.folio.rest.impl;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.folio.rest.RestVerticle;
+import org.folio.rest.tools.PomReader;
+import org.folio.rest.tools.client.test.HttpClientMock2;
+import org.folio.utils.Utils;
+import org.junit.After;
+import org.junit.Before;
+
+import io.restassured.RestAssured;
+import io.restassured.http.Header;
+import io.vertx.core.DeploymentOptions;
+import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonObject;
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
+import io.vertx.ext.unit.TestContext;
+
+public class VertxTestBase {
+
+  private static final String MOCK_RMAPI_CONFIG_SUCCESS_FILE = "RMAPIToCodex/mock_content.json";
+
+
+  protected final Logger logger = LoggerFactory.getLogger("CodexInstancesResourceImplTest");
+  protected final int okapiPort = Utils.getRandomPort();
+  protected final Header tenantHeader = new Header("X-Okapi-Tenant", "codexinstancesresourceimpltest");
+  protected final Header urlHeader = new Header("X-Okapi-Url", "https://localhost:" + okapiPort);
+  protected final Header contentTypeHeader = new Header("Content-Type", "application/json");
+  protected Vertx vertx;
+  // This object is needed to modify RMAPIConfiguration's local
+  // object as a side effect.
+  protected HttpClientMock2 httpClientMock;
+
+  @Before
+  public void setUp(TestContext context) {
+    vertx = Vertx.vertx();
+
+    String moduleName = PomReader.INSTANCE.getModuleName().replaceAll("_", "-");
+    String moduleVersion = PomReader.INSTANCE.getVersion();
+    String moduleId = moduleName + "-" + moduleVersion;
+    logger.info("Test setup starting for " + moduleId);
+
+    final JsonObject conf = new JsonObject();
+    conf.put("http.port", okapiPort);
+    conf.put(HttpClientMock2.MOCK_MODE, "true");
+
+    final DeploymentOptions opt = new DeploymentOptions().setConfig(conf);
+    vertx.deployVerticle(RestVerticle.class.getName(), opt, context.asyncAssertSuccess());
+    RestAssured.port = okapiPort;
+    logger.info("Codex Instances Resource Test Setup Done using port " + okapiPort);
+
+    final Map<String, String> okapiHeaders = new HashMap<>();
+    okapiHeaders.put("X-Okapi-Tenant", "codexinstancesresourceimpltest");
+    okapiHeaders.put("X-Okapi-Url", "https://localhost:" + Integer.toString(okapiPort));
+    httpClientMock = new HttpClientMock2(okapiHeaders.get("X-Okapi-Tenant"), okapiHeaders.get("X-Okapi-Url"));
+    try {
+      // Mocking the RM API Configuration response
+      httpClientMock.setMockJsonContent(MOCK_RMAPI_CONFIG_SUCCESS_FILE);
+    } catch (final IOException e) {
+      context.fail("Cannot read mock file: " + MOCK_RMAPI_CONFIG_SUCCESS_FILE + " - reason: " + e.getMessage());
+    }
+  }
+
+  @After
+  public void tearDown(TestContext context) {
+    logger.info("Codex Instances Resource Testing Complete");
+    vertx.close(context.asyncAssertSuccess());
+  }
+}


### PR DESCRIPTION
## Purpose
Implement /codex-packages-sources

## Approach
Use PomReader.INSTANCE to get module name and version
Moved common set up for endpoint tests into a base class VertxTestBase


#### TODOS and Open Questions
- [x] This PR depends on schema change from PR https://github.com/folio-org/raml/pull/116
