### PR TITLE
MODCXMUX-34 - Implement GET Package Sources

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -35,9 +35,17 @@
           "pathPattern" : "/codex-packages/{id}",
           "permissionsRequired" : [ "codex.packages.item.get" ],
           "modulePermissions": ["configuration.entries.collection.get"]
-        }, {
-          "methods" : [ "GET" ],
-          "pathPattern" : "/codex-packages-sources"
+        }
+      ]
+    },
+    {
+      "id": "codex-packages-sources",
+      "version": "1.0",
+      "interfaceType": "multiple",
+      "handlers": [
+        {
+          "methods": ["GET"],
+          "pathPattern": "/codex-packages-sources"
         }
       ]
     }


### PR DESCRIPTION
## Purpose
As a part of https://issues.folio.org/browse/MODCXMUX-34, module `mod-codex-ekb` should implement `codex-packages-sources` interface and be returned during a call to `/_/proxy/tenants/diku/interfaces/codex-packages-sources` as following
![image](https://user-images.githubusercontent.com/37537790/53797228-69f99f80-3f3e-11e9-8283-ccf86d855938.png)


## Approach
* Modified ModuleDescriptior to have `codex-packages-sources` interface separately 

#### TODOS and Open Questions
- [ ] Define required permissions for an endpoint