### PR TITLE
MODCXEKB-79  Implement GET Package by ID

### DIFF
--- a/src/main/java/org/folio/parser/IdParser.java
+++ b/src/main/java/org/folio/parser/IdParser.java
@@ -2,16 +2,27 @@ package org.folio.parser;
 
 import java.util.ArrayList;
 import java.util.List;
+
 import javax.validation.ValidationException;
+
 import org.springframework.stereotype.Component;
+
+import org.folio.holdingsiq.model.PackageId;
 
 @Component
 public class IdParser {
 
   private static final String INSTANCE_ID_IS_INVALID_ERROR = "Instance id is invalid - %s";
+  private static final String PACKAGE_ID_MISSING_ERROR = "Package and provider id are required";
+  private static final String PACKAGE_ID_INVALID_ERROR = "Package or provider id are invalid";
 
   public Long parseTitleId(String id){
     return parseId(id, 1, INSTANCE_ID_IS_INVALID_ERROR, INSTANCE_ID_IS_INVALID_ERROR).get(0);
+  }
+
+  public PackageId parsePackageId(String id){
+    List<Long> parts = parseId(id, 2, PACKAGE_ID_MISSING_ERROR, PACKAGE_ID_INVALID_ERROR);
+    return PackageId.builder().providerIdPart(parts.get(0)).packageIdPart(parts.get(1)).build();
   }
 
   private List<Long> parseId(String id, int partCount, String wrongCountErrorMessage, String numberFormatErrorMessage) {

--- a/src/main/java/org/folio/rest/impl/CodexPackagesImpl.java
+++ b/src/main/java/org/folio/rest/impl/CodexPackagesImpl.java
@@ -1,43 +1,98 @@
 package org.folio.rest.impl;
 
+import static io.vertx.core.Future.succeededFuture;
+
 import java.util.Collections;
 import java.util.Map;
 
+import javax.validation.ValidationException;
 import javax.ws.rs.core.Response;
 
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Context;
+import io.vertx.core.Handler;
+import io.vertx.core.Vertx;
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import org.folio.codex.RMAPIToCodex;
+import org.folio.holdingsiq.model.OkapiData;
+import org.folio.holdingsiq.service.ConfigurationService;
+import org.folio.holdingsiq.service.exception.ConfigurationServiceException;
+import org.folio.holdingsiq.service.exception.ResourceNotFoundException;
+import org.folio.parser.IdParser;
+import org.folio.rest.jaxrs.model.Package;
 import org.folio.rest.jaxrs.model.Source;
 import org.folio.rest.jaxrs.model.SourceCollection;
 import org.folio.rest.jaxrs.resource.CodexPackages;
 import org.folio.rest.jaxrs.resource.CodexPackagesSources;
 import org.folio.rest.tools.PomReader;
-
-import io.vertx.core.AsyncResult;
-import io.vertx.core.Context;
-import io.vertx.core.Future;
-import io.vertx.core.Handler;
+import org.folio.spring.SpringContextUtil;
 
 /**
  * Package related codex APIs.
  */
 public final class CodexPackagesImpl implements CodexPackages, CodexPackagesSources {
 
+  private final Logger log = LoggerFactory.getLogger(CodexPackagesImpl.class);
+
   private static final String MODULE_SOURCE = "kb";
+
+  @Autowired
+  private ConfigurationService configurationService;
+  @Autowired
+  private IdParser idParser;
+
+
+  public CodexPackagesImpl() {
+    SpringContextUtil.autowireDependencies(this, Vertx.currentContext());
+  }
 
   @Override
   public void getCodexPackages(String query, int offset, int limit, String lang, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
-    asyncResultHandler.handle(Future.succeededFuture(Response.status(Response.Status.NOT_IMPLEMENTED).build()));
+    asyncResultHandler.handle(succeededFuture(Response.status(Response.Status.NOT_IMPLEMENTED).build()));
   }
 
   @Override
   public void getCodexPackagesById(String id, String lang, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
-    asyncResultHandler.handle(Future.succeededFuture(Response.status(Response.Status.NOT_IMPLEMENTED).build()));
+    log.info("method call: getCodexPackagesById");
+
+    configurationService.retrieveConfiguration(new OkapiData(okapiHeaders))
+      .thenCompose(config -> RMAPIToCodex.getPackage(vertxContext, config, idParser.parsePackageId(id)))
+      .thenAccept(pkg -> successfulPkgById(pkg, asyncResultHandler))
+      .exceptionally(throwable -> failedPkgById(id, throwable, asyncResultHandler));
+  }
+
+  private void successfulPkgById(Package pkg, Handler<AsyncResult<Response>> handler) {
+    handler.handle(succeededFuture(GetCodexPackagesByIdResponse.respond200WithApplicationJson(pkg)));
+  }
+
+  private Void failedPkgById(String id, Throwable throwable, Handler<AsyncResult<Response>> handler) {
+    log.error("getCodexPackagesById failed!", throwable);
+
+    Response response;
+    if (throwable.getCause() instanceof ResourceNotFoundException ||
+        throwable.getCause() instanceof ValidationException) {
+      response = GetCodexPackagesByIdResponse.respond404WithTextPlain(id);
+    } else if (throwable.getCause() instanceof ConfigurationServiceException &&
+        ((ConfigurationServiceException) throwable.getCause()).getStatusCode() == 401) {
+      response = GetCodexPackagesByIdResponse.respond401WithTextPlain(throwable.getCause().getMessage());
+    } else {
+      response = GetCodexPackagesByIdResponse.respond500WithTextPlain(throwable.getCause().getMessage());
+    }
+
+    handler.handle(succeededFuture(response));
+
+    return null;
   }
 
   @Override
-  public void getCodexPackagesSources(String lang, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
+  public void getCodexPackagesSources(String lang, Map<String, String> okapiHeaders,
+                                      Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
     String moduleName = PomReader.INSTANCE.getModuleName().replace("_", "-");
     String moduleVersion = PomReader.INSTANCE.getVersion();
-    asyncResultHandler.handle(Future.succeededFuture(GetCodexPackagesSourcesResponse.respond200WithApplicationJson(new SourceCollection()
+    asyncResultHandler.handle(succeededFuture(GetCodexPackagesSourcesResponse.respond200WithApplicationJson(new SourceCollection()
       .withSources(Collections.singletonList(
         new Source()
           .withId(MODULE_SOURCE)

--- a/src/test/java/org/folio/rest/impl/CodexInstancesImplTest.java
+++ b/src/test/java/org/folio/rest/impl/CodexInstancesImplTest.java
@@ -1,20 +1,12 @@
 package org.folio.rest.impl;
 
-import static org.folio.utils.Utils.readMockFile;
 import static org.hamcrest.Matchers.containsString;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
 
-import java.util.concurrent.CompletableFuture;
+import static org.folio.utils.Utils.readMockFile;
 
-import org.folio.holdingsiq.model.Configuration;
-import org.folio.holdingsiq.service.ConfigurationService;
-import org.folio.holdingsiq.service.exception.ConfigurationServiceException;
-import org.folio.spring.SpringContextUtil;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.springframework.beans.factory.annotation.Autowired;
+import java.util.concurrent.CompletableFuture;
 
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
@@ -24,9 +16,18 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import org.folio.holdingsiq.model.Configuration;
+import org.folio.holdingsiq.service.ConfigurationService;
+import org.folio.holdingsiq.service.exception.ConfigurationServiceException;
+import org.folio.spring.SpringContextUtil;
 
 @RunWith(VertxUnitRunner.class)
-public class CodexInstanceResourceImplTest extends VertxTestBase {
+public class CodexInstancesImplTest extends VertxTestBase {
 
   private static final String MOCK_RMAPI_INSTANCE_TITLE_200_RESPONSE_WHEN_FOUND = "RMAPIService/SuccessGetTitleById.json";
   private static final String MOCK_RMAPI_INSTANCE_TITLE_404_RESPONSE_WHEN_NOT_FOUND = "RMAPIConfiguration/mock_content_fail_404.json";

--- a/src/test/java/org/folio/rest/impl/CodexPackagesImplTest.java
+++ b/src/test/java/org/folio/rest/impl/CodexPackagesImplTest.java
@@ -2,20 +2,86 @@ package org.folio.rest.impl;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+
+import static org.folio.utils.Utils.readMockFile;
 
 import java.util.List;
-
-import org.folio.rest.jaxrs.model.Source;
-import org.folio.rest.jaxrs.model.SourceCollection;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import java.util.concurrent.CompletableFuture;
 
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
+import io.vertx.core.http.HttpServer;
+import io.vertx.ext.unit.Async;
+import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import org.folio.holdingsiq.model.Configuration;
+import org.folio.holdingsiq.service.ConfigurationService;
+import org.folio.holdingsiq.service.exception.ConfigurationServiceException;
+import org.folio.rest.jaxrs.model.Package;
+import org.folio.rest.jaxrs.model.Source;
+import org.folio.rest.jaxrs.model.SourceCollection;
+import org.folio.spring.SpringContextUtil;
 
 @RunWith(VertxUnitRunner.class)
 public class CodexPackagesImplTest extends VertxTestBase {
+
+  private static final String MOCK_RMAPI_INSTANCE_PACKAGE_200_RESPONSE_WHEN_FOUND = "RMAPIService/SuccessGetPackageById.json";
+  private static final String MOCK_RMAPI_INSTANCE_PACKAGE_404_RESPONSE_WHEN_NOT_FOUND = "RMAPIConfiguration/mock_content_fail_404.json";
+  
+  private static final String CUSTOMER_ID = "test";
+  private static final String VENDOR_ID = "111";
+  private static final String PACKAGE_ID = "222222";
+  private static final String INVALID_PACKAGE_ID = "999999";
+  private static final String CODEX_PACKAGE_ID = VENDOR_ID + "-" + PACKAGE_ID;
+
+
+  @Autowired
+  private ConfigurationService configurationService;
+
+  @Before
+  public void setUp(TestContext context) {
+    super.setUp(context);
+
+    Async async = context.async();
+    
+    int serverPort = Integer.parseInt(System.getProperty("serverPort", Integer.toString(51234)));
+    String host = "localhost";
+    HttpServer server = vertx.createHttpServer();
+
+    server.requestHandler(req -> {
+      if (req.path().equals(packageByIdURL(PACKAGE_ID))) {
+        req.response().setStatusCode(200).putHeader("content-type", "application/json")
+          .end(readMockFile(MOCK_RMAPI_INSTANCE_PACKAGE_200_RESPONSE_WHEN_FOUND));
+      } else if (req.path().equals(packageByIdURL(INVALID_PACKAGE_ID))) {
+        req.response().setStatusCode(404).putHeader("content-type", "text/plain")
+          .end(readMockFile(MOCK_RMAPI_INSTANCE_PACKAGE_404_RESPONSE_WHEN_NOT_FOUND));
+      } else {
+        req.response().setStatusCode(500).end("Unexpected call: " + req.path());
+      }
+    });
+    server.listen(serverPort, host, ar -> async.complete());
+
+    SpringContextUtil.autowireDependenciesFromFirstContext(this, vertx);
+    
+    doReturn(CompletableFuture.completedFuture(
+      Configuration.builder()
+        .customerId("test")
+        .apiKey("8675309")
+        .url("http://localhost:" + serverPort)
+        .configValid(true).build()))
+      .when(configurationService).retrieveConfiguration(any());
+  }
+
+  private static String packageByIdURL(String packageId) {
+    return String.format("/rm/rmaccounts/%s/vendors/%s/packages/%s", CUSTOMER_ID, VENDOR_ID, packageId);
+  }
 
   @Test
   public void getCodexPackagesSourcesSuccessTest() {
@@ -38,6 +104,76 @@ public class CodexPackagesImplTest extends VertxTestBase {
     assertTrue(sources.get(0).getName().matches("mod-codex-ekb-.*"));
     assertTrue(sources.get(0).getId().matches("kb"));
 
+    logger.info("Test done");
+  }
+
+  @Test
+  public void getCodexPackagesByIdSuccessTest() {
+    logger.info("Testing for successful package id");
+
+    Package pkg = RestAssured
+      .given()
+      .header(tenantHeader)
+      .header(urlHeader)
+      .header(tokenHeader)
+      .header(contentTypeHeader)
+      .get("/codex-packages/" + CODEX_PACKAGE_ID)
+      .then()
+      .contentType(ContentType.JSON)
+      .log()
+      .ifValidationFails()
+      .statusCode(200).extract().as(Package.class);
+
+    assertEquals(CODEX_PACKAGE_ID, pkg.getId());
+    assertEquals("EBSCO", pkg.getProvider());
+    assertEquals(VENDOR_ID, pkg.getProviderId());
+    assertEquals(Package.IsSelected.YES, pkg.getIsSelected());
+
+    // Test done
+    logger.info("Test done");
+  }
+
+  @Test
+  public void getCodexPackagesByIdTitleNotFoundTest() {
+    logger.info("Testing for response when package not found");
+
+    RestAssured
+      .given()
+      .header(tenantHeader)
+      .header(urlHeader)
+      .header(tokenHeader)
+      .header(contentTypeHeader)
+      .get("/codex-packages/" + INVALID_PACKAGE_ID)
+      .then()
+      .log()
+      .ifValidationFails()
+      .statusCode(404);
+
+    // Test done
+    logger.info("Test done");
+  }
+
+  @Test
+  public void getCodexPackagesByIdTitleNotAuth() {
+    logger.info("Testing for response when not authorized");
+
+    CompletableFuture<Object> future = new CompletableFuture<>();
+    future.completeExceptionally(new ConfigurationServiceException("UnAuthorized to access RM API Configuration", 401));
+    doReturn(future).when(configurationService).retrieveConfiguration(any());
+    
+    RestAssured
+      .given()
+      .header(tenantHeader)
+      .header(urlHeader)
+      .header(tokenHeader)
+      .header(contentTypeHeader)
+      .get("/codex-packages/" + CODEX_PACKAGE_ID)
+      .then()
+      .log()
+      .ifValidationFails()
+      .statusCode(401);
+
+    // Test done
     logger.info("Test done");
   }
 

--- a/src/test/java/org/folio/rest/impl/CodexPackagesImplTest.java
+++ b/src/test/java/org/folio/rest/impl/CodexPackagesImplTest.java
@@ -134,7 +134,7 @@ public class CodexPackagesImplTest extends VertxTestBase {
   }
 
   @Test
-  public void getCodexPackagesByIdTitleNotFoundTest() {
+  public void getCodexPackagesByIdPackageNotFoundTest() {
     logger.info("Testing for response when package not found");
 
     RestAssured
@@ -154,7 +154,7 @@ public class CodexPackagesImplTest extends VertxTestBase {
   }
 
   @Test
-  public void getCodexPackagesByIdTitleNotAuth() {
+  public void getCodexPackagesByIdPackageNotAuth() {
     logger.info("Testing for response when not authorized");
 
     CompletableFuture<Object> future = new CompletableFuture<>();

--- a/src/test/resources/RMAPIService/SuccessGetPackageById.json
+++ b/src/test/resources/RMAPIService/SuccessGetPackageById.json
@@ -1,0 +1,32 @@
+{
+  "packageId": 222222,
+  "packageName": "Health & Wellness Resource Center (w/alt health module)",
+  "vendorId": 111,
+  "vendorName": "EBSCO",
+  "isCustom": true,
+  "titleCount": 1,
+  "isSelected": true,
+  "selectedCount": 1,
+  "contentType": "onlinereference",
+  "visibilityData": {
+    "isHidden": true,
+    "reason": "Hidden by Customer"
+  },
+  "customCoverage": {
+    "beginCoverage": "2003-01-01",
+    "endCoverage": "2003-12-12"
+  },
+  "isTokenNeeded": true,
+  "allowEbscoToAddTitles": true,
+  "packageType": "Complete",
+  "proxy": {
+    "id": "",
+    "inherited": true
+  },
+  "packageToken": {
+    "factName": "galesiteid",
+    "helpText": "<ul><li>Enter your Gale<sup></sup> site ID in the space provided below. The site ID may contain a combination of alpha/numeric characters, varying in length. <blockquote><p> Example: The site ID immediately follows /itweb/ in a URL. The site ID in the following URL is …………….</ul>",
+    "prompt": "/itweb/",
+    "value": "1234567"
+  }
+}


### PR DESCRIPTION
## Purpose
According to [MODCXEKB-79](https://issues.folio.org/browse/MODCXEKB-79) implement GET Package By Id method in codex-ekb module

## Approach
Implement GET Package By Id method in codex-ekb module as defined by RAML definition for packages.
Implementation is similar to `getCodexInstancesById`. Method provides for lookup of a package id based on it's unique identifier. For mod-codex-ekb – unique package id is providerId-packagId
