### PR TITLE
Fix pagination calculator

### DIFF
--- a/src/main/java/org/folio/cql2rmapi/query/PaginationCalculator.java
+++ b/src/main/java/org/folio/cql2rmapi/query/PaginationCalculator.java
@@ -11,7 +11,7 @@ public class PaginationCalculator {
     int rmAPILimit = Math.min(limit, RM_API_MAX_COUNT);
     int pageOffsetRMAPI = computePageOffsetForRMAPI(offset, rmAPILimit);
     pages.add(new Page(pageOffsetRMAPI, rmAPILimit));
-    while (checkIfSecondQueryIsNeeded(offset, rmAPILimit, pageOffsetRMAPI)) {
+    while (checkIfSecondQueryIsNeeded(offset, limit, rmAPILimit, pageOffsetRMAPI)) {
       pages.add(new Page(++pageOffsetRMAPI, rmAPILimit));
     }
     return new PaginationInfo(pages, offset % rmAPILimit, limit);
@@ -24,7 +24,7 @@ public class PaginationCalculator {
     return (int) pageOffset;
   }
 
-  private boolean checkIfSecondQueryIsNeeded(int offset, int limit, int pageOffsetRMAPI) {
-    return (offset + limit) > (pageOffsetRMAPI * limit);
+  private boolean checkIfSecondQueryIsNeeded(int offset, int limit, int limitRMAPI, int pageOffsetRMAPI) {
+    return (offset + limit) > (pageOffsetRMAPI * limitRMAPI);
   }
 }

--- a/src/test/java/org/folio/cql2rmapi/query/PaginationCalculatorTest.java
+++ b/src/test/java/org/folio/cql2rmapi/query/PaginationCalculatorTest.java
@@ -1,0 +1,42 @@
+package org.folio.cql2rmapi.query;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+public class PaginationCalculatorTest {
+
+  private PaginationCalculator calculator = new PaginationCalculator();
+
+  @Test
+  public void shouldReturnOnePageWhenLimitSmallerThanRMAPILimit() {
+    PaginationInfo info = calculator.getPagination(0, 50);
+
+    assertEquals(0, info.getFirstObjectIndex());
+    assertEquals(50, info.getLimit());
+
+    assertEquals(1, info.getPages().size());
+    assertEquals(1, info.getPages().get(0).getOffset());
+    assertEquals(50, info.getPages().get(0).getLimit());
+  }
+
+  @Test
+  public void shouldReturnMultiplePagesWhenLimitBiggerThanRMAPILimit() {
+    PaginationInfo info = calculator.getPagination(0, 143);
+
+    assertEquals(2, info.getPages().size());
+    assertEquals(1, info.getPages().get(0).getOffset());
+    assertEquals(100, info.getPages().get(0).getLimit());
+    assertEquals(2, info.getPages().get(1).getOffset());
+    assertEquals(100, info.getPages().get(1).getLimit());
+  }
+
+  @Test
+  public void shouldReturnOnePageWhenLimitEqualToRMAPILimit() {
+    PaginationInfo info = calculator.getPagination(0, 100);
+
+    assertEquals(1, info.getPages().size());
+    assertEquals(1, info.getPages().get(0).getOffset());
+    assertEquals(100, info.getPages().get(0).getLimit());
+  }
+}


### PR DESCRIPTION
## Purpose
Fix issue with calculating which pages ekb module needs to get from RM API

## Approach
During refactoring I incorrectly used limit parameter related to mod-codex-ekb instead of limit related to RM API, so pageOffsetRMAPI should be multiplied by limitRMAPI, instead of limit.
