### PR TITLE
Release 1.3.0

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,7 @@
-## 1.2.0 2019-03-15
+# 1.3.0 2019-03-20
+ * [MODCXEKB-95] - Fix failing API Tests - Updated path for downloaded schemas
+
+# 1.2.0 2019-03-15
  * [MODCXEKB-72] - Define normalized Package fields mapping
  * [MODCXEKB-74] - Define mormaized title-package fields
  * [MODCXEKB-79] - Implement GET Package by ID

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.folio</groupId>
   <artifactId>mod-codex-ekb</artifactId>
-  <version>1.3.0-SNAPSHOT</version>
+  <version>1.3.0</version>
 
   <name>EBSCO Knowledge Base Codex Module</name>
   <url>https://github.com/folio-org/mod-codex-ekb</url>
@@ -23,7 +23,7 @@
     <connection>scm:git:git://github.com/folio-org/mod-codex-ekb.git</connection>
     <developerConnection>scm:git:git@github.com:folio-org/mod-codex-ekb.git</developerConnection>
     <url>https://github.com/folio-org/mod-codex-ekb.git</url>
-    <tag>HEAD</tag>
+    <tag>v1.3.0</tag>
   </scm>
 
   <ciManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.folio</groupId>
   <artifactId>mod-codex-ekb</artifactId>
-  <version>1.3.0</version>
+  <version>1.4.0-SNAPSHOT</version>
 
   <name>EBSCO Knowledge Base Codex Module</name>
   <url>https://github.com/folio-org/mod-codex-ekb</url>
@@ -23,7 +23,7 @@
     <connection>scm:git:git://github.com/folio-org/mod-codex-ekb.git</connection>
     <developerConnection>scm:git:git@github.com:folio-org/mod-codex-ekb.git</developerConnection>
     <url>https://github.com/folio-org/mod-codex-ekb.git</url>
-    <tag>v1.3.0</tag>
+    <tag>HEAD</tag>
   </scm>
 
   <ciManagement>


### PR DESCRIPTION
## Purpose
Create release which resolves API test issues . 

Specifically api tests were failing due to similarly named schemas and adjustment has been made to specify path for Codex schema

https://github.com/folio-org/mod-codex-ekb/pull/98

*  https://issues.folio.org/browse/MODCXEKB-95 

## Approach
- Follow documented release procedure for mvn module