### PR TITLE
MODKBEKBJ-505 Set log factory to Log4j2LogDelegateFactory in tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -443,6 +443,11 @@
         <version>3.0.0-M5</version>
         <configuration>
           <useSystemClassLoader>false</useSystemClassLoader>
+          <systemPropertyVariables>
+            <vertx.logger-delegate-factory-class-name>
+              io.vertx.core.logging.Log4j2LogDelegateFactory
+            </vertx.logger-delegate-factory-class-name>
+          </systemPropertyVariables>
         </configuration>
       </plugin>
     </plugins>


### PR DESCRIPTION
## Purpose
Set vert.x log factory to Log4j2LogDelegateFactory in tests to enable proper log message output, in particular for parametrized messages

## Approach
Update maven surefire plugin configuration with `vertx.logger-delegate-factory-class-name` property set to `io.vertx.core.logging.Log4j2LogDelegateFactory`